### PR TITLE
KVStore::remove Implementation Part 1

### DIFF
--- a/src/turtle_kv/core/algo/compute_running_total.hpp
+++ b/src/turtle_kv/core/algo/compute_running_total.hpp
@@ -14,10 +14,10 @@ namespace turtle_kv {
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-template <bool kDecayValue = false>
+template <bool kDecayValue>
 inline batt::RunningTotal compute_running_total(
     batt::WorkerPool& worker_pool,
-    const MergeCompactor::ResultSet</*decay_to_items=*/false>& result_set,
+    const MergeCompactor::ResultSet<kDecayValue>& result_set,
     DecayToItem<kDecayValue> decay_to_item [[maybe_unused]] = {})
 {
   auto merged_edits = result_set.get();

--- a/src/turtle_kv/core/merge_compactor.cpp
+++ b/src/turtle_kv/core/merge_compactor.cpp
@@ -429,6 +429,12 @@ template <bool kDecayToItems>
 /*static*/ auto MergeCompactor::ResultSet<kDecayToItems>::concat(ResultSet&& first,
                                                                  ResultSet&& second) -> ResultSet
 {
+  if (first.size() > 0 && second.size() > 0) {
+    BATT_CHECK_LT(first.get_max_key(), second.get_min_key())
+        << "All elements in the first ResultSet should be strictly less than the elements in the "
+           "second ResultSet!";
+  }
+
   ResultSet ans;
 
   //----- --- -- -  -  -   -
@@ -494,6 +500,8 @@ template <bool kDecayToItems>
                 [first_size](Chunk<const value_type*>& chunk_from_second) {
                   chunk_from_second.offset += first_size;
                 });
+
+  ans.chunks_.back().offset = first_size + second.chunks_.back().offset;
 
   first.clear();
   second.clear();

--- a/src/turtle_kv/core/merge_compactor.test.cpp
+++ b/src/turtle_kv/core/merge_compactor.test.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <turtle_kv/core/testing/generate.hpp>
 #include <turtle_kv/import/env.hpp>
 
 #include <batteries/stream_util.hpp>
@@ -23,7 +24,10 @@ using namespace batt::int_types;
 using batt::as_seq;
 using batt::WorkerPool;
 
+using llfs::StableStringStore;
+
 using turtle_kv::CInterval;
+using turtle_kv::DecayToItem;
 using turtle_kv::EditSlice;
 using turtle_kv::EditView;
 using turtle_kv::getenv_as;
@@ -38,6 +42,8 @@ using turtle_kv::Slice;
 using turtle_kv::Status;
 using turtle_kv::StatusOr;
 using turtle_kv::ValueView;
+
+using turtle_kv::testing::RandomStringGenerator;
 
 namespace seq = turtle_kv::seq;
 
@@ -480,6 +486,178 @@ TEST(MergeCompactor, ResultSetDropKeyRange)
 
     // end - for all seeds
   }
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+class ResultSetConcatTest : public ::testing::Test
+{
+ public:
+  void generate_edits(usize num_edits, bool needs_sort = true)
+  {
+    std::unordered_set<KeyView> keys_set;
+
+    std::default_random_engine rng{/*seed=*/30};
+    RandomStringGenerator generate_key;
+    while (this->all_edits_.size() < num_edits) {
+      KeyView key = generate_key(rng, this->store_);
+      if (keys_set.contains(key)) {
+        continue;
+      }
+      keys_set.emplace(key);
+      this->all_edits_.emplace_back(key,
+                                    ValueView::from_str(this->store_.store(std::string(100, 'a'))));
+    }
+
+    if (needs_sort) {
+      std::sort(this->all_edits_.begin(), this->all_edits_.end(), KeyOrder{});
+    } else {
+      if (std::is_sorted(this->all_edits_.begin(), this->all_edits_.end(), KeyOrder{})) {
+        std::swap(this->all_edits_.front(), this->all_edits_.back());
+      }
+    }
+  }
+
+  template <bool kDecayToItems>
+  MergeCompactor::ResultSet<kDecayToItems> concat(std::vector<EditView>&& first,
+                                                  std::vector<EditView>&& second,
+                                                  DecayToItem<kDecayToItems> decay_to_item)
+  {
+    usize first_size = first.size();
+    usize second_size = second.size();
+
+    MergeCompactor::ResultSet<kDecayToItems> first_result_set;
+    first_result_set.append(std::move(first));
+    MergeCompactor::ResultSet<kDecayToItems> second_result_set;
+    second_result_set.append(std::move(second));
+
+    EXPECT_EQ(first_result_set.size(), first_size);
+    EXPECT_EQ(second_result_set.size(), second_size);
+
+    MergeCompactor::ResultSet<kDecayToItems> concatenated_result_set =
+        MergeCompactor::ResultSet<kDecayToItems>::concat(std::move(first_result_set),
+                                                         std::move(second_result_set));
+
+    return concatenated_result_set;
+  }
+
+  template <bool kDecayToItems>
+  void verify_result_set(const MergeCompactor::ResultSet<kDecayToItems>& result_set,
+                         const std::vector<EditView>& edits)
+  {
+    EXPECT_EQ(result_set.size(), edits.size());
+
+    usize i = 0;
+    for (const EditView& edit : result_set.get()) {
+      EXPECT_EQ(edit, edits[i]);
+      ++i;
+    }
+  }
+
+  llfs::StableStringStore store_;
+  std::vector<EditView> all_edits_;
+};
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+TEST_F(ResultSetConcatTest, Concat)
+{
+  // Generate an edit batch of size 200.
+  //
+  usize n = 200;
+  this->generate_edits(n);
+
+  // Divide the edit batch in half, and create ResultSet objects out of each half.
+  //
+  std::vector<EditView> first{this->all_edits_.begin(), this->all_edits_.begin() + (n / 2)};
+  std::vector<EditView> second{this->all_edits_.begin() + (n / 2), this->all_edits_.end()};
+
+  MergeCompactor::ResultSet<false> concatenated_result_set =
+      this->concat(std::move(first), std::move(second), DecayToItem<false>{});
+
+  // Concatenated ResultSet should have the same size as the original edit batch, and should
+  // also contain the same items in the same order.
+  //
+  this->verify_result_set(concatenated_result_set, this->all_edits_);
+
+  // Now, repeat the process qith unequal sized inputs
+  //
+  first.assign(this->all_edits_.begin(), this->all_edits_.begin() + (n / 4));
+  second.assign(this->all_edits_.begin() + (n / 4), this->all_edits_.end());
+
+  concatenated_result_set = this->concat(std::move(first), std::move(second), DecayToItem<false>{});
+
+  this->verify_result_set(concatenated_result_set, this->all_edits_);
+
+  // Finally, test with empty input.
+  //
+  first = {};
+  second.assign(this->all_edits_.begin(), this->all_edits_.begin() + (n / 4));
+
+  concatenated_result_set = this->concat(std::move(first), std::move(second), DecayToItem<false>{});
+
+  this->verify_result_set(concatenated_result_set,
+                          {this->all_edits_.begin(), this->all_edits_.begin() + (n / 4)});
+
+  first = {};
+  second = {};
+  concatenated_result_set = this->concat(std::move(first), std::move(second), DecayToItem<false>{});
+  EXPECT_EQ(concatenated_result_set.size(), 0);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+TEST_F(ResultSetConcatTest, FragmentedConcat)
+{
+  usize n = 200;
+  this->generate_edits(n);
+
+  std::vector<EditView> first{this->all_edits_.begin(), this->all_edits_.begin() + (n / 2)};
+  std::vector<EditView> second{this->all_edits_.begin() + (n / 2), this->all_edits_.end()};
+
+  MergeCompactor::ResultSet<false> first_result_set;
+  first_result_set.append(std::move(first));
+  MergeCompactor::ResultSet<false> second_result_set;
+  second_result_set.append(std::move(second));
+
+  // Drop some keys fron the beginning of the ResultSet.
+  //
+  first_result_set.drop_before_n(n / 10);
+
+  // Drop some keys in the middle of the ResultSet.
+  //
+  auto second_range_begin = this->all_edits_.begin() + (3 * n / 5);
+  auto second_range_end = this->all_edits_.begin() + (3 * n / 4);
+  Interval<KeyView> second_range{second_range_begin->key, second_range_end->key};
+  second_result_set.drop_key_range_half_open(second_range);
+
+  MergeCompactor::ResultSet<false> concatenated_result_set =
+      MergeCompactor::ResultSet<false>::concat(std::move(first_result_set),
+                                               std::move(second_result_set));
+
+  std::vector<EditView> concat_edits{this->all_edits_.begin() + (n / 10),
+                                     this->all_edits_.begin() + (3 * n / 5)};
+  concat_edits.insert(concat_edits.end(),
+                      this->all_edits_.begin() + (3 * n / 4),
+                      this->all_edits_.end());
+  this->verify_result_set(concatenated_result_set, concat_edits);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+TEST_F(ResultSetConcatTest, ConcatDeath)
+{
+  usize n = 200;
+  this->generate_edits(n, /*needs_sort*/ false);
+
+  std::vector<EditView> first{this->all_edits_.begin(), this->all_edits_.begin() + (n / 2)};
+  std::vector<EditView> second{this->all_edits_.begin() + (n / 2), this->all_edits_.end()};
+
+  // We should panic since first and second have overlapping key ranges.
+  //
+  EXPECT_DEATH(this->concat(std::move(first), std::move(second), DecayToItem<false>{}),
+               "All elements in the first ResultSet should be strictly less than the elements in "
+               "the second ResultSet!");
 }
 
 }  // namespace

--- a/src/turtle_kv/core/testing/generate.hpp
+++ b/src/turtle_kv/core/testing/generate.hpp
@@ -12,6 +12,7 @@
 #include <random>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 namespace turtle_kv {
@@ -184,8 +185,11 @@ class RandomResultSetGenerator : public MinMaxSize<usize{1} << 24>
   }
 
   template <bool kDecayToItems, typename Rng>
-  MergeCompactor::ResultSet</*kDecayToItems=*/kDecayToItems>
-  operator()(DecayToItem<kDecayToItems>, Rng& rng, llfs::StableStringStore& store)
+  MergeCompactor::ResultSet</*kDecayToItems=*/kDecayToItems> operator()(
+      DecayToItem<kDecayToItems>,
+      Rng& rng,
+      llfs::StableStringStore& store,
+      const std::vector<KeyView>& to_delete)
   {
     using ResultSet = MergeCompactor::ResultSet</*kDecayToItems=*/kDecayToItems>;
     using Item = typename ResultSet::value_type;
@@ -193,12 +197,23 @@ class RandomResultSetGenerator : public MinMaxSize<usize{1} << 24>
     const usize n = this->Super::pick_size(rng);
     std::vector<EditView> items;
 
+    for (const KeyView& delete_key : to_delete) {
+      items.emplace_back(delete_key, ValueView::deleted());
+    }
+
+    std::unordered_set<KeyView> deleted_items_set{to_delete.begin(), to_delete.end()};
     while (items.size() < n) {
-      for (usize i = items.size(); i < n; ++i) {
+      for (usize i = items.size(); i < n;) {
         char ch = '_' + (i & 31);
-        items.emplace_back(this->key_generator_(rng, store),
+        KeyView key = this->key_generator_(rng, store);
+        if (deleted_items_set.count(key)) {
+          continue;
+        }
+        items.emplace_back(key,
                            ValueView::from_str(store.store(std::string(this->value_size_, ch))));
+        ++i;
       }
+
       std::sort(items.begin(), items.end(), KeyOrder{});
       items.erase(std::unique(items.begin(),
                               items.end(),

--- a/src/turtle_kv/core/testing/generate.test.cpp
+++ b/src/turtle_kv/core/testing/generate.test.cpp
@@ -7,9 +7,14 @@
 
 namespace {
 
+using batt::int_types::usize;
+
 using turtle_kv::DecayToItem;
 using turtle_kv::ItemView;
 using turtle_kv::KeyOrder;
+using turtle_kv::KeyView;
+using turtle_kv::StatusOr;
+using turtle_kv::ValueView;
 using turtle_kv::testing::RandomResultSetGenerator;
 
 template <bool kDecayToItems>
@@ -24,10 +29,28 @@ TEST(GenerateTest, Test)
 
   g.set_size(200);
 
-  ResultSet<true> result_set = g(DecayToItem<true>{}, rng, store);
+  std::vector<KeyView> to_delete;
+  ResultSet<true> result_set = g(DecayToItem<true>{}, rng, store, to_delete);
 
   EXPECT_TRUE(std::is_sorted(result_set.get().begin(), result_set.get().end(), KeyOrder{}));
   EXPECT_EQ(result_set.get().size(), 200u);
+
+  auto result_set_slice = result_set.get();
+  usize i = 0;
+  for (const ItemView& edit : result_set_slice) {
+    if (i % 2) {
+      to_delete.emplace_back(edit.key);
+    }
+    ++i;
+  }
+
+  ResultSet<false> result_set_with_deletes = g(DecayToItem<false>{}, rng, store, to_delete);
+  for (const KeyView& deleted_key : to_delete) {
+    StatusOr<ValueView> deleted_value = result_set_with_deletes.find_key(deleted_key);
+    EXPECT_TRUE(deleted_value.ok());
+    EXPECT_EQ(*deleted_value, ValueView::deleted());
+  }
+  EXPECT_EQ(to_delete.size(), result_set_with_deletes.size() / 2);
 }
 
 }  // namespace

--- a/src/turtle_kv/kv_store.cpp
+++ b/src/turtle_kv/kv_store.cpp
@@ -667,11 +667,19 @@ StatusOr<ValueView> KVStore::get(const KeyView& key) noexcept /*override*/
                                        this->metrics_.mem_table_get_latency,
                                        observed_state->mem_table_->get(key));
 
+  const auto return_memtable_value =
+      [](Optional<ValueView> mem_table_value,
+         FastCountMetric<u64>& get_count_metric) -> StatusOr<ValueView> {
+    get_count_metric.add(1);
+    if (mem_table_value->is_delete()) {
+      return {batt::StatusCode::kNotFound};
+    }
+    return *mem_table_value;
+  };
+
   if (value) {
     if (!value->needs_combine()) {
-      this->metrics_.mem_table_get_count.add(1);
-      // VLOG(1) << "found key " << batt::c_str_literal(key) << " in active MemTable";
-      return *value;
+      return return_memtable_value(value, this->metrics_.mem_table_get_count);
     }
   }
 
@@ -693,13 +701,15 @@ StatusOr<ValueView> KVStore::get(const KeyView& key) noexcept /*override*/
       if (value) {
         *value = combine(*value, *delta_value);
         if (!value->needs_combine()) {
-          this->metrics_.delta_log2_get_count[batt::log2_ceil(observed_deltas_size - i)].add(1);
-          return *value;
+          return return_memtable_value(
+              value,
+              this->metrics_.delta_log2_get_count[batt::log2_ceil(observed_deltas_size - i)]);
         }
       } else {
         if (!delta_value->needs_combine()) {
-          this->metrics_.delta_log2_get_count[batt::log2_ceil(observed_deltas_size - i)].add(1);
-          return *delta_value;
+          return return_memtable_value(
+              delta_value,
+              this->metrics_.delta_log2_get_count[batt::log2_ceil(observed_deltas_size - i)]);
         }
         value = delta_value;
       }
@@ -774,7 +784,6 @@ StatusOr<usize> KVStore::scan_keys(const KeyView& min_key,
   this->metrics_.scan_count.add(1);
 
   KVStoreScanner scanner{*this, min_key};
-  scanner.set_keys_only(true);
   BATT_REQUIRE_OK(scanner.start());
 
   return scanner.read_keys(items_out);
@@ -783,9 +792,7 @@ StatusOr<usize> KVStore::scan_keys(const KeyView& min_key,
 //
 Status KVStore::remove(const KeyView& key) noexcept /*override*/
 {
-  (void)key;
-
-  return batt::StatusCode::kUnimplemented;
+  return this->put(key, ValueView::deleted());
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/turtle_kv/kv_store_scanner.cpp
+++ b/src/turtle_kv/kv_store_scanner.cpp
@@ -435,15 +435,33 @@ Status KVStoreScanner::set_next_item()
     ScanLevel* scan_level = this->heap_.first();
 
     if (!this->next_item_) {
-      this->next_item_.emplace(scan_level->item(this->keys_only_));
+      this->next_item_.emplace(scan_level->item());
 
     } else if (this->next_item_->key == scan_level->key) {
-      if (!this->keys_only_ && this->next_item_->needs_combine()) {
+      // Search for a terminal value for the item and combine it if necessary.
+      //
+      if (this->next_item_->needs_combine()) {
         this->next_item_->value = combine(this->next_item_->value, scan_level->value());
       }
 
     } else {
-      break;
+      // We have reached a terminal value for this->next_item_. Now, we have to decide whether
+      // we want to return the item to the function's caller OR discard it, because the terminal
+      // value represents a deleted item.
+      //
+      if (this->next_item_->value == ValueView::deleted()) {
+        // Discard the deleted item and continue on to the next iteration of the loop, skipping
+        // the logic to advance the current scan_level. We do this because we now need to set the
+        // first key in the current scan_level to this->next_item_ to examine it next.
+        //
+        this->next_item_ = None;
+        if (this->needs_resume_) {
+          BATT_REQUIRE_OK(this->resume());
+        }
+        continue;
+      } else {
+        break;
+      }
     }
 
     if (scan_level->advance()) {
@@ -567,7 +585,7 @@ Status KVStoreScanner::set_next_item()
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-EditView KVStoreScanner::ScanLevel::item(bool key_only) const
+EditView KVStoreScanner::ScanLevel::item() const
 {
   return batt::case_of(
       this->state_impl,
@@ -575,58 +593,37 @@ EditView KVStoreScanner::ScanLevel::item(bool key_only) const
         BATT_PANIC() << "illegal state";
         BATT_UNREACHABLE();
       },
-      [this, key_only](const MemTableScanState<ARTBase::Synchronized::kTrue>& state) -> EditView {
+      [this](const MemTableScanState<ARTBase::Synchronized::kTrue>& state) -> EditView {
         MemTableEntry entry;
         const bool found = state.mem_table_->hash_index().find_key(this->key, entry);
         BATT_CHECK(found);
 
-        if (key_only) {
-          return EditView{entry.key_, ValueView{}};
-        }
         return EditView{entry.key_, entry.value_};
       },
-      [this, key_only](const MemTableScanState<ARTBase::Synchronized::kFalse>& state) -> EditView {
+      [this](const MemTableScanState<ARTBase::Synchronized::kFalse>& state) -> EditView {
         const MemTableEntry* entry = state.mem_table_->hash_index().unsynchronized_find_key(key);
         BATT_CHECK_NOT_NULLPTR(entry);
 
-        if (key_only) {
-          return EditView{entry->key_, ValueView{}};
-        }
         return EditView{entry->key_, entry->value_};
       },
-      [key_only](const MemTableValueScanState<ARTBase::Synchronized::kTrue>& state) -> EditView {
+      [](const MemTableValueScanState<ARTBase::Synchronized::kTrue>& state) -> EditView {
         const MemTableValueEntry& entry = state.art_scanner_->get_value();
-        if (key_only) {
-          return EditView{entry.key_view(), ValueView{}};
-        }
         return EditView{entry.key_view(), entry.value_view()};
       },
-      [key_only](const MemTableValueScanState<ARTBase::Synchronized::kFalse>& state) -> EditView {
+      [](const MemTableValueScanState<ARTBase::Synchronized::kFalse>& state) -> EditView {
         const MemTableValueEntry& entry = state.art_scanner_->get_value();
-        if (key_only) {
-          return EditView{entry.key_view(), ValueView{}};
-        }
         return EditView{entry.key_view(), entry.value_view()};
       },
       [](const Slice<const EditView>& state) -> EditView {
         return state.front();
       },
-      [this, key_only](const TreeLevelScanState& state) -> EditView {
-        if (key_only) {
-          return EditView{this->key, ValueView{}};
-        }
+      [this](const TreeLevelScanState& state) -> EditView {
         return EditView{this->key, get_value(state.kv_slice.front())};
       },
-      [this, key_only](const TreeLevelScanShardedState& state) -> EditView {
-        if (key_only) {
-          return EditView{this->key, ValueView{}};
-        }
+      [this](const TreeLevelScanShardedState& state) -> EditView {
         return EditView{this->key, state.kv_slice.front_value()};
       },
-      [this, key_only](const ShardedLeafScanState& state) -> EditView {
-        if (key_only) {
-          return EditView{this->key, ValueView{}};
-        }
+      [this](const ShardedLeafScanState& state) -> EditView {
         return EditView{this->key, BATT_OK_RESULT_OR_PANIC(state.leaf_scanner_->front_value())};
       });
 }

--- a/src/turtle_kv/kv_store_scanner.hpp
+++ b/src/turtle_kv/kv_store_scanner.hpp
@@ -198,7 +198,7 @@ class KVStoreScanner
 
     /** \brief Returns the current item as an EditView.
      */
-    EditView item(bool key_only) const;
+    EditView item() const;
 
     /** \brief Returns the value of the current item.
      */
@@ -306,11 +306,6 @@ class KVStoreScanner
 
   StatusOr<usize> read_keys(const Slice<KeyView>& buffer);
 
-  void set_keys_only(bool b) noexcept
-  {
-    this->keys_only_ = b;
-  }
-
   //+++++++++++-+-+--+----- --- -- -  -  -   --
  private:
   Status validate_page_layout(i32 height, const llfs::PinnedPage& pinned_page);
@@ -353,7 +348,6 @@ class KVStoreScanner
   boost::container::static_vector<NodeScanState, kMaxTreeHeight - 1> tree_scan_path_;
   boost::container::small_vector<ScanLevel, kMaxHeapSize + 32> scan_levels_;
   StackMerger<ScanLevel, ScanLevelMinHeapOrder, kMaxHeapSize> heap_;
-  bool keys_only_ = false;
   Optional<ShardedLeafPageScanner> sharded_leaf_scanner_;
 };
 

--- a/src/turtle_kv/tree/algo/nodes.hpp
+++ b/src/turtle_kv/tree/algo/nodes.hpp
@@ -169,6 +169,9 @@ struct NodeAlgorithms {
       BATT_ASSIGN_OK_RESULT(const bool done, combine_in_place(&value, found_in_level));
       if (done) {
         BATT_CHECK(value);
+        if (value->is_delete()) {
+          return {batt::StatusCode::kNotFound};
+        }
         return *value;
       }
     }
@@ -179,7 +182,7 @@ struct NodeAlgorithms {
 
     BATT_REQUIRE_OK(combine_in_place(&value, subtree_result));
 
-    if (!value) {
+    if (!value || value->is_delete()) {
       return {batt::StatusCode::kNotFound};
     }
 

--- a/src/turtle_kv/tree/in_memory_leaf.cpp
+++ b/src/turtle_kv/tree/in_memory_leaf.cpp
@@ -29,7 +29,8 @@ StatusOr<std::unique_ptr<InMemoryLeaf>> InMemoryLeaf::try_split()
 {
   BATT_CHECK(this->edit_size_totals);
   BATT_CHECK(!this->edit_size_totals->empty());
-  BATT_CHECK_EQ(this->result_set.size() + 1,  //
+  BATT_CHECK(this->result_set);
+  BATT_CHECK_EQ(this->result_set->size() + 1,  //
                 this->edit_size_totals->size());
 
   BATT_ASSIGN_OK_RESULT(SplitPlan plan, this->make_split_plan());
@@ -37,16 +38,16 @@ StatusOr<std::unique_ptr<InMemoryLeaf>> InMemoryLeaf::try_split()
   // Sanity checks.
   //
   BATT_CHECK_LT(0, plan.split_point);
-  BATT_CHECK_LT(plan.split_point, this->result_set.size());
+  BATT_CHECK_LT(plan.split_point, this->result_set->size());
 
   auto new_sibling =
       std::make_unique<InMemoryLeaf>(batt::make_copy(this->pinned_leaf_page_), this->tree_options);
 
   new_sibling->result_set = this->result_set;
   {
-    const usize pre_drop_size = new_sibling->result_set.size();
-    new_sibling->result_set.drop_before_n(plan.split_point);
-    const usize post_drop_size = new_sibling->result_set.size();
+    const usize pre_drop_size = new_sibling->result_set->size();
+    new_sibling->result_set->drop_before_n(plan.split_point);
+    const usize post_drop_size = new_sibling->result_set->size();
 
     BATT_CHECK_EQ(post_drop_size, pre_drop_size - plan.split_point)
         << BATT_INSPECT(pre_drop_size) << BATT_INSPECT(plan);
@@ -55,13 +56,13 @@ StatusOr<std::unique_ptr<InMemoryLeaf>> InMemoryLeaf::try_split()
   new_sibling->edit_size_totals = this->edit_size_totals;
   new_sibling->edit_size_totals->drop_front(plan.split_point);
 
-  this->result_set.drop_after_n(plan.split_point);
+  this->result_set->drop_after_n(plan.split_point);
   this->edit_size_totals->drop_back(this->edit_size_totals->size() - plan.split_point - 1);
 
-  BATT_CHECK_EQ(this->result_set.size() + 1,  //
+  BATT_CHECK_EQ(this->result_set->size() + 1,  //
                 this->edit_size_totals->size());
 
-  BATT_CHECK_EQ(new_sibling->result_set.size() + 1,  //
+  BATT_CHECK_EQ(new_sibling->result_set->size() + 1,  //
                 new_sibling->edit_size_totals->size());
 
   BATT_CHECK(!batt::is_case<NeedsSplit>(this->get_viability()))
@@ -149,12 +150,54 @@ auto InMemoryLeaf::make_split_plan() const -> StatusOr<SplitPlan>
   return plan;
 }
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+Status InMemoryLeaf::apply_batch_update(BatchUpdate& update) noexcept
+{
+  Optional<BoxedSeq<EditSlice>> current_result_set = None;
+  if (this->pinned_leaf_page_ && !this->result_set) {
+    // In this case, we have initialized a new InMemoryLeaf from a PackedLeaf. Use the
+    // items from the PackedLeaf to merge with the incoming update.
+    //
+    const PackedLeafPage& packed_leaf = PackedLeafPage::view_of(this->pinned_leaf_page_);
+    current_result_set = packed_leaf.as_edit_slice_seq();
+  } else if (this->result_set) {
+    // In this case, we have an existing InMemoryLeaf that we are applying updates to.
+    // Use the existing ResultSet to merge with the incoming update.
+    //
+    current_result_set = this->result_set->live_edit_slices();
+  }
+
+  // If we didn't enter either of the above two cases, we must have an empty tree that we are
+  // applying updates to.
+  //
+  BATT_CHECK_IMPLIES(!current_result_set, !this->pinned_leaf_page_ && !this->result_set);
+
+  BATT_ASSIGN_OK_RESULT(this->result_set,
+                        update.context.merge_compact_edits</*decay_to_items=*/true>(
+                            global_max_key(),
+                            [&](MergeCompactor& compactor) -> Status {
+                              compactor.push_level(update.result_set.live_edit_slices());
+                              if (current_result_set) {
+                                compactor.push_level(std::move(*current_result_set));
+                              }
+                              return OkStatus();
+                            }));
+
+  this->result_set->update_has_page_refs(update.result_set.has_page_refs());
+  this->set_edit_size_totals(update.context.compute_running_total(*this->result_set));
+
+  return OkStatus();
+}
+
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
 {
+  BATT_CHECK(this->result_set);
+
   BATT_CHECK(!batt::is_case<NeedsSplit>(this->get_viability()))
       << BATT_INSPECT(this->get_viability()) << BATT_INSPECT(this->get_items_size())
       << BATT_INSPECT(this->tree_options.flush_size());
@@ -180,7 +223,7 @@ Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
             if (task_i == 0) {
               return build_leaf_page_in_job(this->tree_options.trie_index_reserve_size(),
                                             page_buffer,
-                                            this->result_set.get());
+                                            this->result_set->get());
             }
             BATT_CHECK_EQ(task_i, 1);
 
@@ -188,7 +231,7 @@ Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
                                                 filter_bits_per_key,
                                                 filter_page_size,
                                                 page_buffer.page_id(),
-                                                this->result_set.get());
+                                                this->result_set->get());
           }));
 
   BATT_CHECK_EQ(this->future_id_.exchange(future_id), ~u64{0});

--- a/src/turtle_kv/tree/in_memory_leaf.hpp
+++ b/src/turtle_kv/tree/in_memory_leaf.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <turtle_kv/tree/batch_update.hpp>
 #include <turtle_kv/tree/packed_leaf_page.hpp>
 #include <turtle_kv/tree/subtree_viability.hpp>
 #include <turtle_kv/tree/tree_options.hpp>
@@ -32,10 +33,17 @@ struct InMemoryLeaf {
 
   llfs::PinnedPage pinned_leaf_page_;
   TreeOptions tree_options;
-  MergeCompactor::ResultSet</*decay_to_items=*/false> result_set;
+  Optional<MergeCompactor::ResultSet</*decay_to_items=*/true>> result_set;
   std::shared_ptr<const batt::RunningTotal> shared_edit_size_totals_;
   Optional<batt::RunningTotal::slice_type> edit_size_totals;
   mutable std::atomic<u64> future_id_{~u64{0}};
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  static std::unique_ptr<InMemoryLeaf> unpack(llfs::PinnedPage&& pinned_leaf_page,
+                                              const TreeOptions& tree_options,
+                                              const PackedLeafPage& packed_leaf,
+                                              batt::WorkerPool& worker_pool) noexcept;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -43,6 +51,7 @@ struct InMemoryLeaf {
                         const TreeOptions& tree_options_arg) noexcept
       : pinned_leaf_page_{std::move(pinned_leaf_page)}
       , tree_options{tree_options_arg}
+      , result_set{None}
   {
   }
 
@@ -56,13 +65,15 @@ struct InMemoryLeaf {
 
   usize get_item_count() const
   {
-    return this->result_set.size();
+    BATT_CHECK(this->result_set);
+    return this->result_set->size();
   }
 
   usize get_items_size() const
   {
     BATT_CHECK(this->edit_size_totals);
-    BATT_CHECK_EQ(this->edit_size_totals->size(), this->result_set.size() + 1);
+    BATT_CHECK(this->result_set);
+    BATT_CHECK_EQ(this->edit_size_totals->size(), this->result_set->size() + 1);
 
     if (this->edit_size_totals->empty()) {
       return 0;
@@ -72,17 +83,20 @@ struct InMemoryLeaf {
 
   KeyView get_min_key() const
   {
-    return this->result_set.get_min_key();
+    BATT_CHECK(this->result_set);
+    return this->result_set->get_min_key();
   }
 
   KeyView get_max_key() const
   {
-    return this->result_set.get_max_key();
+    BATT_CHECK(this->result_set);
+    return this->result_set->get_max_key();
   }
 
   StatusOr<ValueView> find_key(const KeyView& key) const
   {
-    return this->result_set.find_key(key);
+    BATT_CHECK(this->result_set);
+    return this->result_set->find_key(key);
   }
 
   SubtreeViability get_viability();
@@ -90,6 +104,8 @@ struct InMemoryLeaf {
   StatusOr<std::unique_ptr<InMemoryLeaf>> try_split();
 
   StatusOr<SplitPlan> make_split_plan() const;
+
+  Status apply_batch_update(BatchUpdate& update) noexcept;
 
   Status start_serialize(TreeSerializeContext& context);
 

--- a/src/turtle_kv/tree/in_memory_leaf.hpp
+++ b/src/turtle_kv/tree/in_memory_leaf.hpp
@@ -40,13 +40,6 @@ struct InMemoryLeaf {
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
-  static std::unique_ptr<InMemoryLeaf> unpack(llfs::PinnedPage&& pinned_leaf_page,
-                                              const TreeOptions& tree_options,
-                                              const PackedLeafPage& packed_leaf,
-                                              batt::WorkerPool& worker_pool) noexcept;
-
-  //+++++++++++-+-+--+----- --- -- -  -  -   -
-
   explicit InMemoryLeaf(llfs::PinnedPage&& pinned_leaf_page,
                         const TreeOptions& tree_options_arg) noexcept
       : pinned_leaf_page_{std::move(pinned_leaf_page)}

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -352,10 +352,6 @@ Status InMemoryNode::flush_if_necessary(BatchUpdateContext& context, bool force_
   //
   const MaxPendingBytes max_pending = this->find_max_pending();
 
-  if (!max_pending.byte_count) {
-    return {batt::StatusCode::kUnavailable};
-  }
-
   const bool flush_needed = force_flush ||                                                      //
                             (max_pending.byte_count >= this->tree_options.min_flush_size()) ||  //
                             this->has_too_many_tiers();

--- a/src/turtle_kv/tree/in_memory_node.test.cpp
+++ b/src/turtle_kv/tree/in_memory_node.test.cpp
@@ -373,7 +373,7 @@ void SubtreeBatchUpdateScenario::run()
                 .page_loader = *page_loader,
                 .cancel_token = batt::CancelToken{},
             },
-        .result_set = result_set_generator(DecayToItem<false>{}, rng, strings),
+        .result_set = result_set_generator(DecayToItem<false>{}, rng, strings, {}),
         .edit_size_totals = None,
     };
     update.update_edit_size_totals();

--- a/src/turtle_kv/tree/in_memory_node.test.cpp
+++ b/src/turtle_kv/tree/in_memory_node.test.cpp
@@ -186,6 +186,42 @@ struct SubtreeBatchUpdateScenario {
   void run();
 };
 
+struct BatchUpdateGenerator {
+  StableStringStore strings;
+  RandomResultSetGenerator result_set_generator;
+  std::vector<KeyView> pending_deletes;
+  usize delete_frequency;
+
+  explicit BatchUpdateGenerator(usize delete_frequency_param,
+                                const RandomResultSetGenerator& gen) noexcept
+      : result_set_generator{gen}
+      , delete_frequency{delete_frequency_param}
+  {
+  }
+
+  template <typename Rng>
+  ResultSet<false> next_batch(usize batch_i, Rng& rng, bool update_pending_deletes = false)
+  {
+    ResultSet<false> result_set =
+        result_set_generator(DecayToItem<false>{}, rng, this->strings, this->pending_deletes);
+
+    if (update_pending_deletes) {
+      if (!this->pending_deletes.empty()) {
+        this->pending_deletes.clear();
+      }
+
+      if (batch_i % this->delete_frequency == 0) {
+        BATT_CHECK(this->pending_deletes.empty());
+        for (const EditView& edit : result_set.get()) {
+          pending_deletes.emplace_back(edit.key);
+        }
+      }
+    }
+
+    return result_set;
+  }
+};
+
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 TEST(InMemoryNodeTest, Segment)
@@ -341,11 +377,11 @@ void SubtreeBatchUpdateScenario::run()
                              tree_options,
                              /*byte_capacity=*/1500 * kMiB);
 
-  StableStringStore strings;
   RandomResultSetGenerator result_set_generator;
-  turtle_kv::OrderedMapTable<absl::btree_map<std::string_view, std::string_view>> expected_table;
-
   result_set_generator.set_key_size(24).set_value_size(100).set_size(items_per_leaf);
+  BatchUpdateGenerator update_generator{/*delete_frequency=*/5, /*gen=*/result_set_generator};
+
+  turtle_kv::OrderedMapTable<absl::btree_map<std::string_view, std::string_view>> expected_table;
 
   Subtree tree = Subtree::make_empty();
 
@@ -373,7 +409,9 @@ void SubtreeBatchUpdateScenario::run()
                 .page_loader = *page_loader,
                 .cancel_token = batt::CancelToken{},
             },
-        .result_set = result_set_generator(DecayToItem<false>{}, rng, strings, {}),
+        // TODO [vsilai 2026-01-09] Enable delete support for batch generation.
+        //
+        .result_set = update_generator.next_batch(i, rng, /*update_pending_deletes=*/false),
         .edit_size_totals = None,
     };
     update.update_edit_size_totals();

--- a/src/turtle_kv/tree/packed_leaf_page.hpp
+++ b/src/turtle_kv/tree/packed_leaf_page.hpp
@@ -320,6 +320,8 @@ struct PackedLeafLayoutPlan {
   usize page_size;
   usize key_count;
   usize trie_index_reserved_size;
+  usize avg_key_len;
+  usize drop_count;
 
   usize trie_index_begin;
   usize trie_index_end;
@@ -361,6 +363,8 @@ struct PackedLeafLayoutPlan {
   }
 
   void check_valid(std::string_view label) const;
+
+  usize compute_trie_step_size() const;
 };
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -370,6 +374,8 @@ BATT_OBJECT_PRINT_IMPL((inline),
                        (page_size,
                         key_count,
                         trie_index_reserved_size,
+                        avg_key_len,
+                        drop_count,
                         trie_index_begin,
                         trie_index_end,
                         leaf_header_begin,
@@ -390,6 +396,43 @@ BATT_OBJECT_PRINT_IMPL((inline),
 inline void PackedLeafLayoutPlan::check_valid(std::string_view label) const
 {
   BATT_CHECK(this->is_valid()) << *this << BATT_INSPECT_STR(label);
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+inline usize PackedLeafLayoutPlan::compute_trie_step_size() const
+{
+  BATT_CHECK_GT(this->key_count, 0);
+  BATT_CHECK_GT(this->avg_key_len, 0);
+
+  // If there are no deleted items in this leaf, return 16.
+  //
+  if (this->drop_count == 0) {
+    return 16;
+  }
+
+  usize trie_buffer_size = this->trie_index_end - this->trie_index_begin;
+  BATT_CHECK_GT(trie_buffer_size, 0);
+
+  // Determine the number of pivot keys to intialize the trie with by using the size of the trie
+  // buffer and the average key length across the items in the leaf.
+  //
+  usize pivot_count = trie_buffer_size / this->avg_key_len;
+  usize step_size = (this->key_count + pivot_count - 1) / pivot_count;
+
+  BATT_CHECK_GT(step_size, 0);
+
+  // If the calculated step size is already a power of 2, return it now.
+  //
+  if ((step_size & (step_size - 1)) == 0) {
+    return step_size;
+  }
+
+  // Otherwise, calculate the nearest power of 2 less than `step_size`.
+  //
+  i32 shift = batt::log2_floor(step_size);
+  BATT_CHECK_GE(shift, 0);
+  return usize{1} << shift;
 }
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
@@ -423,6 +466,7 @@ class PackedLeafLayoutPlanBuilder
     plan.page_size = this->page_size;
     plan.key_count = BATT_CHECKED_CAST(u32, this->key_count);
     plan.trie_index_reserved_size = this->trie_index_reserved_size;
+    plan.avg_key_len = plan.key_count > 0 ? this->key_data_size / plan.key_count : 0;
 
     usize offset = 0;
     const auto append = [&offset](usize size) {
@@ -513,23 +557,21 @@ struct LeafItemsSummary {
 struct AddLeafItemsSummary {
   LeafItemsSummary operator()(const LeafItemsSummary& prior, const EditView& edit) const noexcept
   {
-    if (!decays_to_item(edit.value)) {
-      LOG(ERROR) << "TODO [tastolfi 2025-05-27] support deletes:" << BATT_INSPECT(edit);
-
-      return LeafItemsSummary{
-          .drop_count = prior.drop_count + 1,
-          .key_count = prior.key_count,
-          .key_data_size = prior.key_data_size,
-          .value_data_size = prior.value_data_size,
-      };
-    } else {
-      return LeafItemsSummary{
-          .drop_count = prior.drop_count,
-          .key_count = prior.key_count + 1,
-          .key_data_size = prior.key_data_size + (edit.key.size() + 4),
-          .value_data_size = prior.value_data_size + (1 + edit.value.size()),
-      };
+    usize drop_count = prior.drop_count;
+    if (!decays_to_item(edit)) {
+      drop_count++;
     }
+    return LeafItemsSummary{
+        .drop_count = drop_count,
+        .key_count = prior.key_count + 1,
+        .key_data_size = prior.key_data_size + (edit.key.size() + 4),
+        .value_data_size = prior.value_data_size + (1 + edit.value.size()),
+    };
+  }
+
+  LeafItemsSummary operator()(const LeafItemsSummary& prior, const ItemView& edit) const noexcept
+  {
+    return AddLeafItemsSummary{}(BATT_FORWARD(prior), EditView::from_item_view(edit));
   }
 
   LeafItemsSummary operator()(const LeafItemsSummary& left,
@@ -556,8 +598,6 @@ template <typename ItemsRangeT>
                                              LeafItemsSummary{},
                                              AddLeafItemsSummary{});
 
-  BATT_CHECK_EQ(summary.drop_count, 0);
-
   PackedLeafLayoutPlanBuilder plan_builder;
 
   plan_builder.page_size = page_size;
@@ -567,6 +607,8 @@ template <typename ItemsRangeT>
   plan_builder.trie_index_reserved_size = trie_index_reserved_size;
 
   PackedLeafLayoutPlan plan = plan_builder.build();
+
+  plan.drop_count = summary.drop_count;
 
   return plan;
 }
@@ -693,7 +735,7 @@ inline PackedLeafPage* build_leaf_page(MutableBuffer buffer,
   if (plan.trie_index_reserved_size > 0) {
     const MutableBuffer trie_buffer{(void*)advance_pointer(buffer.data(), plan.trie_index_begin),
                                     plan.trie_index_end - plan.trie_index_begin};
-    usize step_size = 16;
+    usize step_size = plan.compute_trie_step_size();
     bool retried = false;
     batt::SmallVec<std::string_view, 1024> pivot_keys;
     for (;;) {

--- a/src/turtle_kv/tree/subtree.cpp
+++ b/src/turtle_kv/tree/subtree.cpp
@@ -139,14 +139,7 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
 
           auto new_leaf = std::make_unique<InMemoryLeaf>(llfs::PinnedPage{}, tree_options);
 
-          new_leaf->result_set = update.result_set;
-
-          if (!update.edit_size_totals) {
-            update.update_edit_size_totals();
-          }
-
-          new_leaf->set_edit_size_totals(std::move(*update.edit_size_totals));
-          update.edit_size_totals = None;
+          BATT_REQUIRE_OK(new_leaf->apply_batch_update(update));
 
           return Subtree{std::move(new_leaf)};
         }
@@ -171,22 +164,10 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
           //+++++++++++-+-+--+----- --- -- -  -  -   -
           // Case: {BatchUpdate} + {PackedLeafPage} => InMemoryLeaf
 
-          const PackedLeafPage& packed_leaf = PackedLeafPage::view_of(pinned_page);
           auto new_leaf =
               std::make_unique<InMemoryLeaf>(batt::make_copy(pinned_page), tree_options);
 
-          BATT_ASSIGN_OK_RESULT(  //
-              new_leaf->result_set,
-              update.context.merge_compact_edits(  //
-                  global_max_key(),
-                  [&](MergeCompactor& compactor) -> Status {
-                    compactor.push_level(update.result_set.live_edit_slices());
-                    compactor.push_level(packed_leaf.as_edit_slice_seq());
-                    return OkStatus();
-                  }));
-
-          new_leaf->set_edit_size_totals(
-              update.context.compute_running_total(new_leaf->result_set));
+          BATT_REQUIRE_OK(new_leaf->apply_batch_update(update));
 
           return Subtree{std::move(new_leaf)};
 
@@ -214,19 +195,7 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
 
         BATT_CHECK_EQ(parent_height, 2);
 
-        BATT_ASSIGN_OK_RESULT(
-            in_memory_leaf->result_set,
-            update.context.merge_compact_edits(
-                global_max_key(),
-                [&](MergeCompactor& compactor) -> Status {
-                  compactor.push_level(update.result_set.live_edit_slices());
-                  compactor.push_level(in_memory_leaf->result_set.live_edit_slices());
-                  return OkStatus();
-                }));
-
-        in_memory_leaf->result_set.update_has_page_refs(update.result_set.has_page_refs());
-        in_memory_leaf->set_edit_size_totals(
-            update.context.compute_running_total(in_memory_leaf->result_set));
+        BATT_REQUIRE_OK(in_memory_leaf->apply_batch_update(update));
 
         return Subtree{std::move(in_memory_leaf)};
       },
@@ -256,6 +225,16 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
           return OkStatus();
         },
         [&](NeedsSplit needs_split) {
+          // TODO [vsilai 2025-12-09]: revist when VLDB changes are merged in.
+          //
+          if (needs_split.too_many_segments && !needs_split.too_many_pivots &&
+              !needs_split.keys_too_large) {
+            Status flush_status = new_subtree->try_flush(update.context);
+            if (flush_status.ok() && batt::is_case<Viable>(new_subtree->get_viability())) {
+              return OkStatus();
+            }
+          }
+
           Status status =
               new_subtree->split_and_grow(update.context, tree_options, key_upper_bound);
 
@@ -266,7 +245,7 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
         },
         [&](const NeedsMerge& needs_merge) {
           BATT_CHECK(!needs_merge.single_pivot)
-              << "TODO [tastolfi 2025-03-26] implement flush and shrink";
+              << "TODO [vsilai 2026-01-08] implement flush and shrink";
           return OkStatus();
         }));
   }

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -107,4 +107,5 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
                !needs_split.too_many_pivots;
       });
 }
+
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -107,22 +107,4 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
                !needs_split.too_many_pivots;
       });
 }
-
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-//
-inline bool is_root_viable(const SubtreeViability& viability)
-{
-  return batt::case_of(
-      viability,
-      [](const Viable&) {
-        return true;
-      },
-      [](const NeedsSplit&) {
-        return false;
-      },
-      [](const NeedsMerge& needs_merge) {
-        return !needs_merge.single_pivot;
-      });
-}
-
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -108,4 +108,21 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
       });
 }
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+inline bool is_root_viable(const SubtreeViability& viability)
+{
+  return batt::case_of(
+      viability,
+      [](const Viable&) {
+        return true;
+      },
+      [](const NeedsSplit&) {
+        return false;
+      },
+      [](const NeedsMerge& needs_merge) {
+        return !needs_merge.single_pivot;
+      });
+}
+
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/testing/random_leaf_generator.hpp
+++ b/src/turtle_kv/tree/testing/random_leaf_generator.hpp
@@ -59,7 +59,7 @@ class RandomLeafGenerator
 
     // Generate a sorted run of random key/value pairs.
     //
-    result.result_set = this->items_generator_(decay_to_items, rng, store, {});
+    result.result_set = this->items_generator_(decay_to_items, rng, store, /*deleted=*/{});
 
     batt::WorkerPool& worker_pool = batt::WorkerPool::null_pool();
 

--- a/src/turtle_kv/tree/testing/random_leaf_generator.hpp
+++ b/src/turtle_kv/tree/testing/random_leaf_generator.hpp
@@ -59,7 +59,7 @@ class RandomLeafGenerator
 
     // Generate a sorted run of random key/value pairs.
     //
-    result.result_set = this->items_generator_(decay_to_items, rng, store);
+    result.result_set = this->items_generator_(decay_to_items, rng, store, {});
 
     batt::WorkerPool& worker_pool = batt::WorkerPool::null_pool();
 
@@ -72,7 +72,7 @@ class RandomLeafGenerator
     // Compute a running total of packed sizes, so we can split the result set in to leaf pages.
     //
     batt::RunningTotal running_total =
-        compute_running_total(worker_pool, result.result_set, DecayToItem<true>{});
+        compute_running_total(worker_pool, result.result_set, DecayToItem<kDecayToItems>{});
 
     SplitParts page_parts = split_parts(       //
         running_total,                         //


### PR DESCRIPTION
First PR for the implementation of `KVStore::remove`.

This PR includes the following changes:

- Decay to items support
- Client facing function updates in the `KVStore` and `KVStoreScanner` classes
- Test infrastructure updates and refactoring (to be continued in the next PR, since more test cases are incoming...)
- Bug fix (and corresponding test cases) for `MergeCompactor::concat`