### PR TITLE
Add support for page cache overcommit

### DIFF
--- a/src/turtle_kv/checkpoint.hpp
+++ b/src/turtle_kv/checkpoint.hpp
@@ -81,6 +81,7 @@ class Checkpoint
    */
   StatusOr<Checkpoint> serialize(const TreeOptions& tree_options,
                                  llfs::PageCacheJob& job,
+                                 llfs::PageCacheOvercommit& overcommit,
                                  batt::WorkerPool& worker_pool) const noexcept;
 
   /** \brief Returns the in-memory view of the checkpoint tree.
@@ -131,11 +132,13 @@ class Checkpoint
    */
   bool is_durable() const noexcept;
 
-  /** \brief Applys a batch update to this Checkpoint's tree to produce a new Checkpoint.
+  /** \brief Applies a batch update to this Checkpoint's tree to produce a new Checkpoint.
    */
   StatusOr<Checkpoint> flush_batch(batt::WorkerPool& worker_pool,
                                    llfs::PageCacheJob& job,
                                    const TreeOptions& tree_options,
+                                   BatchUpdateMetrics& metrics,
+                                   llfs::PageCacheOvercommit& overcommit,
                                    std::unique_ptr<DeltaBatch>&& batch,
                                    const batt::CancelToken& cancel_token) noexcept;
 

--- a/src/turtle_kv/checkpoint_generator.hpp
+++ b/src/turtle_kv/checkpoint_generator.hpp
@@ -81,7 +81,8 @@ class CheckpointGenerator
    *
    * \return The number of batches accepted if successful; error Status otherwise.
    */
-  StatusOr<usize> apply_batch(std::unique_ptr<DeltaBatch>&& batch) noexcept;
+  StatusOr<usize> apply_batch(std::unique_ptr<DeltaBatch>&& batch,
+                              llfs::PageCacheOvercommit& overcommit) noexcept;
 
   /** \brief Finalize the current checkpoint rollup and return a CheckpointJob that can be handed to
    * a checkpoint committer.
@@ -94,7 +95,8 @@ class CheckpointGenerator
    */
   StatusOr<std::unique_ptr<CheckpointJob>> finalize_checkpoint(
       batt::Grant&& token,
-      std::shared_ptr<batt::Grant::Issuer>&& token_issuer) noexcept;
+      std::shared_ptr<batt::Grant::Issuer>&& token_issuer,
+      llfs::PageCacheOvercommit& overcommit) noexcept;
 
   llfs::PageCacheJob& page_cache_job() const
   {
@@ -119,7 +121,7 @@ class CheckpointGenerator
 
   /** \brief Serializes any deferred pages in the current base_checkpoint_ tree.
    */
-  Status serialize_checkpoint() noexcept;
+  Status serialize_checkpoint(llfs::PageCacheOvercommit& overcommit) noexcept;
 
   /** \brief Clears `this->roots_to_remove_` by deleting obsolete root pages from the current job's
    * root set.

--- a/src/turtle_kv/kv_store.cpp
+++ b/src/turtle_kv/kv_store.cpp
@@ -1078,7 +1078,8 @@ StatusOr<std::unique_ptr<CheckpointJob>> KVStore::apply_batch_to_checkpoint(
           out << "Finalizing checkpoint early due to cache overcommit;"
               << BATT_INSPECT(this->checkpoint_batch_count_);
         },
-        this->page_cache());
+        this->page_cache(),
+        this->metrics_.overcommit);
   }
 
   // Else if we have reached the target checkpoint distance, then flush the checkpoint and start a
@@ -1328,6 +1329,11 @@ void KVStore::collect_stats(
   fn("page_cache.get_count", page_cache.get_count.get());
 
   emit_latency("page_cache.allocate_page_latency", page_cache.allocate_page_alloc_latency);
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+  // Page cache overcommit metrics.
+  //
+  fn("page_cache.overcommit.trigger_count", this->metrics_.overcommit.trigger_count.get());
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
   // Tree Node related stats.

--- a/src/turtle_kv/kv_store.test.cpp
+++ b/src/turtle_kv/kv_store.test.cpp
@@ -109,6 +109,7 @@ TEST(KVStoreTest, CreateAndOpen)
           auto p_storage_context =
               llfs::StorageContext::make_shared(batt::Runtime::instance().default_scheduler(),  //
                                                 scoped_io_ring->get_io_ring());
+
           BATT_CHECK_OK(KVStore::configure_storage_context(*p_storage_context,
                                                            tree_options,
                                                            runtime_options));

--- a/src/turtle_kv/kv_store_metrics.hpp
+++ b/src/turtle_kv/kv_store_metrics.hpp
@@ -3,6 +3,8 @@
 #include <turtle_kv/config.hpp>
 //
 
+#include <turtle_kv/on_page_cache_overcommit.hpp>
+
 #include <turtle_kv/import/int_types.hpp>
 #include <turtle_kv/import/metrics.hpp>
 
@@ -50,6 +52,8 @@ struct KVStoreMetrics {
   StatsMetric<i64> mem_table_count_stats;
   CountMetric<i64> mem_table_log_bytes_allocated{0};
   CountMetric<i64> mem_table_log_bytes_freed{0};
+
+  OvercommitMetrics overcommit;
 
 #if TURTLE_KV_PROFILE_UPDATES
 

--- a/src/turtle_kv/kv_store_scanner.cpp
+++ b/src/turtle_kv/kv_store_scanner.cpp
@@ -29,7 +29,9 @@ TURTLE_KV_ENV_PARAM(bool, turtlekv_use_sharded_leaf_scanner, false);
 {
   auto& m = KVStoreScanner::metrics();
   m.ctor_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.ctor_latency};
+#endif
 
   if (this->pinned_state_->mem_table_->has_ordered_index()) {
     this->mem_table_scanner_.emplace(this->pinned_state_->mem_table_->ordered_index(), min_key);
@@ -46,10 +48,10 @@ TURTLE_KV_ENV_PARAM(bool, turtlekv_use_sharded_leaf_scanner, false);
                                             i32 tree_height,
                                             const KeyView& min_key,
                                             llfs::PageSize trie_index_sharded_view_size,
-                                            Optional<PageSliceStorage> slice_storage) noexcept
+                                            PageSliceStorage* slice_storage) noexcept
     : pinned_state_{nullptr}
     , page_loader_{page_loader}
-    , slice_storage_{slice_storage ? std::addressof(*slice_storage) : nullptr}
+    , slice_storage_{slice_storage}
     , root_{root}
     , trie_index_sharded_view_size_{trie_index_sharded_view_size}
     , tree_height_{tree_height}
@@ -80,10 +82,14 @@ Status KVStoreScanner::start()
 {
   auto& m = KVStoreScanner::metrics();
   m.start_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.start_latency};
+#endif
 
   if (this->pinned_state_) {
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.start_deltas_latency};
+#endif
 
     const usize n_deltas = this->pinned_state_->deltas_.size();
 
@@ -175,11 +181,15 @@ Status KVStoreScanner::start()
   //
   if (this->root_.is_valid()) {
     {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.start_enter_subtree_latency};
+#endif
       BATT_REQUIRE_OK(this->enter_subtree(this->tree_height_, this->root_, std::false_type{}));
     }
     {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.start_resume_latency};
+#endif
       BATT_REQUIRE_OK(this->resume());
     }
   }
@@ -188,7 +198,9 @@ Status KVStoreScanner::start()
   //
   {
     m.init_heap_size_stats.update(this->scan_levels_.size());
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.start_build_heap_latency};
+#endif
     this->heap_.reset(as_slice(this->scan_levels_), /*minimum_capacity=*/kMaxHeapSize);
   }
 
@@ -425,7 +437,9 @@ Status KVStoreScanner::set_next_item()
 {
   auto& m = KVStoreScanner::metrics();
   m.next_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.next_latency};
+#endif
 
   for (;;) {
     if (this->heap_.empty()) {
@@ -447,12 +461,16 @@ Status KVStoreScanner::set_next_item()
     }
 
     if (scan_level->advance()) {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<8>{},
                          KVStoreScanner::metrics().heap_update_latency};
+#endif
       this->heap_.update_first();
     } else {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<8>{},
                          KVStoreScanner::metrics().heap_remove_latency};
+#endif
       this->heap_.remove_first();
       this->needs_resume_ = true;
     }
@@ -669,6 +687,8 @@ ValueView KVStoreScanner::ScanLevel::value() const
 
 namespace {
 
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
 template <typename MemTableScanStateT>
 BATT_ALWAYS_INLINE bool scan_level_mem_table_advance_impl(KVStoreScanner::ScanLevel* scan_level,
                                                           MemTableScanStateT& state)
@@ -676,7 +696,9 @@ BATT_ALWAYS_INLINE bool scan_level_mem_table_advance_impl(KVStoreScanner::ScanLe
   auto& m = KVStoreScanner::metrics();
 
   m.art_advance_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.art_advance_latency};
+#endif
 
   state.art_scanner_->advance();
   if (state.art_scanner_->is_done()) {
@@ -695,7 +717,9 @@ bool KVStoreScanner::ScanLevel::advance()
   auto& m = KVStoreScanner::metrics();
 
   m.scan_level_advance_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.scan_level_advance_latency};
+#endif
 
   return batt::case_of(
       this->state_impl,
@@ -803,8 +827,10 @@ template <bool kInsertHeap>
         this->active_levels_ |= (u64{1} << buffer_level_i);
         ScanLevel& level = kv_scanner.scan_levels_.emplace_back(first_slice, this, buffer_level_i);
         if (kInsertHeap) {
+#if TURTLE_KV_PROFILE_QUERIES
           LatencyTimer timer{batt::Every2ToTheConst<8>{},
                              KVStoreScanner::metrics().heap_insert_latency};
+#endif
           kv_scanner.heap_.insert(&level);
         }
       }
@@ -814,6 +840,7 @@ template <bool kInsertHeap>
                             level,
                             kv_scanner.page_loader_,
                             llfs::PinPageToJob::kFalse,
+                            llfs::PageCacheOvercommit::not_allowed(),
                             this->pivot_i_,
                             kv_scanner.min_key_);
 
@@ -822,8 +849,10 @@ template <bool kInsertHeap>
         this->active_levels_ |= (u64{1} << buffer_level_i);
         ScanLevel& level = kv_scanner.scan_levels_.emplace_back(first_slice, this, buffer_level_i);
         if (kInsertHeap) {
+#if TURTLE_KV_PROFILE_QUERIES
           LatencyTimer timer{batt::Every2ToTheConst<8>{},
                              KVStoreScanner::metrics().heap_insert_latency};
+#endif
           kv_scanner.heap_.insert(&level);
         }
       }
@@ -855,15 +884,19 @@ template <bool kInsertHeap>
 
     ScanLevel& level = kv_scanner.scan_levels_.emplace_back(sharded_slice, this, 0);
     if (kInsertHeap) {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<8>{},
                          KVStoreScanner::metrics().heap_insert_latency};
+#endif
       kv_scanner.heap_.insert(&level);
     }
   } else {
     ScanLevel& level = kv_scanner.scan_levels_.emplace_back(first_slice, this, 0);
     if (kInsertHeap) {
+#if TURTLE_KV_PROFILE_QUERIES
       LatencyTimer timer{batt::Every2ToTheConst<8>{},
                          KVStoreScanner::metrics().heap_insert_latency};
+#endif
       kv_scanner.heap_.insert(&level);
     }
   }
@@ -976,7 +1009,9 @@ auto KVStoreScanner::NodeScanState::pull_next_sharded(i32 buffer_level_i) -> Sha
   auto& m = KVStoreScanner::metrics();
 
   m.pull_next_sharded_count.add(1);
+#if TURTLE_KV_PROFILE_QUERIES
   LatencyTimer timer{batt::Every2ToTheConst<10>{}, m.pull_next_sharded_latency};
+#endif
 
   ShardedLevelVector& sharded_scanners = std::get<ShardedLevelVector>(this->level_scanners_);
   PackedLevelShardedScanner& level_scanner = sharded_scanners[buffer_level_i];

--- a/src/turtle_kv/kv_store_scanner.hpp
+++ b/src/turtle_kv/kv_store_scanner.hpp
@@ -290,7 +290,7 @@ class KVStoreScanner
                           i32 tree_height,
                           const KeyView& min_key,
                           llfs::PageSize trie_index_sharded_view_size,
-                          Optional<PageSliceStorage> slice_storage) noexcept;
+                          PageSliceStorage* slice_storage) noexcept;
 
   ~KVStoreScanner() noexcept;
 

--- a/src/turtle_kv/on_page_cache_overcommit.cpp
+++ b/src/turtle_kv/on_page_cache_overcommit.cpp
@@ -9,8 +9,11 @@ namespace turtle_kv {
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 void on_page_cache_overcommit(const std::function<void(std::ostream& out)>& context_fn,
-                              llfs::PageCache& cache)
+                              llfs::PageCache& cache,
+                              OvercommitMetrics& metrics)
 {
+  metrics.trigger_count.add(1);
+
   auto& cache_slots = llfs::PageCacheSlot::Pool::Metrics::instance();
 
   const auto print_page_alloc_info = [&](std::ostream& out) {

--- a/src/turtle_kv/on_page_cache_overcommit.cpp
+++ b/src/turtle_kv/on_page_cache_overcommit.cpp
@@ -1,0 +1,38 @@
+#include <turtle_kv/on_page_cache_overcommit.hpp>
+//
+#include <turtle_kv/util/memory_stats.hpp>
+
+#include <turtle_kv/import/logging.hpp>
+
+namespace turtle_kv {
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+void on_page_cache_overcommit(const std::function<void(std::ostream& out)>& context_fn,
+                              llfs::PageCache& cache)
+{
+  auto& cache_slots = llfs::PageCacheSlot::Pool::Metrics::instance();
+
+  const auto print_page_alloc_info = [&](std::ostream& out) {
+    for (const llfs::PageDeviceEntry* entry : cache.all_devices()) {
+      if (!entry->can_alloc || !entry->arena.has_allocator()) {
+        continue;
+      }
+      out << entry->arena.allocator().debug_info() << "\n";
+    }
+  };
+
+  // TODO [tastolfi 2025-11-28] remove? silence?
+  //
+  LOG(INFO) << context_fn << std::endl
+            << BATT_INSPECT(cache_slots.admit_count) << BATT_INSPECT(cache_slots.insert_count)
+            << BATT_INSPECT(cache_slots.erase_count) << BATT_INSPECT(cache_slots.evict_count)
+            << std::endl
+            << BATT_INSPECT(cache_slots.estimate_cache_bytes()) << "("
+            << batt::dump_size(cache_slots.estimate_cache_bytes()) << ")" << std::endl
+            << BATT_INSPECT(cache_slots.estimate_pinned_bytes()) << "("
+            << batt::dump_size(cache_slots.estimate_pinned_bytes()) << ")" << std::endl
+            << print_page_alloc_info << dump_memory_stats();
+}
+
+}  // namespace turtle_kv

--- a/src/turtle_kv/on_page_cache_overcommit.hpp
+++ b/src/turtle_kv/on_page_cache_overcommit.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include <batteries/metrics/metric_collectors.hpp>
 #define TURTLE_KV_ON_PAGE_CACHE_OVERCOMMIT_HPP
 
 #include <turtle_kv/config.hpp>
 //
+
+#include <turtle_kv/import/metrics.hpp>
 
 #include <llfs/page_cache.hpp>
 
@@ -11,7 +14,14 @@
 
 namespace turtle_kv {
 
+struct OvercommitMetrics {
+  /** \brief The total number of times overcommit was triggered.
+   */
+  CountMetric<u64> trigger_count;
+};
+
 void on_page_cache_overcommit(const std::function<void(std::ostream& out)>& context_fn,
-                              llfs::PageCache& cache);
+                              llfs::PageCache& cache,
+                              OvercommitMetrics& metrics);
 
 }  // namespace turtle_kv

--- a/src/turtle_kv/on_page_cache_overcommit.hpp
+++ b/src/turtle_kv/on_page_cache_overcommit.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#define TURTLE_KV_ON_PAGE_CACHE_OVERCOMMIT_HPP
+
+#include <turtle_kv/config.hpp>
+//
+
+#include <llfs/page_cache.hpp>
+
+#include <functional>
+#include <ostream>
+
+namespace turtle_kv {
+
+void on_page_cache_overcommit(const std::function<void(std::ostream& out)>& context_fn,
+                              llfs::PageCache& cache);
+
+}  // namespace turtle_kv

--- a/src/turtle_kv/tree/batch_update.hpp
+++ b/src/turtle_kv/tree/batch_update.hpp
@@ -119,7 +119,7 @@ inline StatusOr<MergeCompactor::ResultSet<kDecayToItems>> BatchUpdateContext::me
   MergeCompactor::OutputBuffer<kDecayToItems> edit_buffer;
 
   this->worker_pool.reset();
-  StatusOr<MergeCompactor::ResultSet</*decay_to_items=*/false>> result_set =
+  StatusOr<MergeCompactor::ResultSet<kDecayToItems>> result_set =
       compactor.read(edit_buffer, max_key);
 
 #if TURTLE_KV_PROFILE_UPDATES

--- a/src/turtle_kv/tree/batch_update.hpp
+++ b/src/turtle_kv/tree/batch_update.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <turtle_kv/tree/batch_update_metrics.hpp>
+
 #include <turtle_kv/core/algo/compute_running_total.hpp>
 
 #include <turtle_kv/core/merge_compactor.hpp>
@@ -23,6 +25,8 @@ struct BatchUpdateContext {
   batt::WorkerPool& worker_pool;
   llfs::PageLoader& page_loader;
   batt::CancelToken cancel_token;
+  BatchUpdateMetrics& metrics;
+  llfs::PageCacheOvercommit& overcommit;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -39,6 +43,11 @@ struct BatchUpdateContext {
   batt::RunningTotal compute_running_total(
       const MergeCompactor::ResultSet</*decay_to_items=*/false>& result_set) const
   {
+#if TURTLE_KV_PROFILE_UPDATES
+    this->metrics.running_total_count.add(1);
+    LatencyTimer timer{this->metrics.latency_sample_rate, this->metrics.running_total_latency};
+#endif  // TURTLE_KV_PROFILE_UPDATES
+
     return ::turtle_kv::compute_running_total(this->worker_pool, result_set);
   }
 };
@@ -94,6 +103,11 @@ template <typename GeneratorFn>
 inline StatusOr<MergeCompactor::ResultSet</*decay_to_items=*/false>>
 BatchUpdateContext::merge_compact_edits(const KeyView& max_key, GeneratorFn&& generator_fn)
 {
+#if TURTLE_KV_PROFILE_UPDATES
+  this->metrics.merge_compact_count.add(1);
+  LatencyTimer timer{this->metrics.latency_sample_rate, this->metrics.merge_compact_latency};
+#endif  // TURTLE_KV_PROFILE_UPDATES
+
   MergeCompactor compactor{this->worker_pool};
 
   compactor.start_push_levels();
@@ -103,7 +117,22 @@ BatchUpdateContext::merge_compact_edits(const KeyView& max_key, GeneratorFn&& ge
   MergeCompactor::EditBuffer edit_buffer;
 
   this->worker_pool.reset();
-  return compactor.read(edit_buffer, max_key);
+  StatusOr<MergeCompactor::ResultSet</*decay_to_items=*/false>> result_set =
+      compactor.read(edit_buffer, max_key);
+
+#if TURTLE_KV_PROFILE_UPDATES
+
+  if (result_set.ok()) {
+    const usize result_size = result_set->size();
+    this->metrics.merge_compact_key_count.add(result_size);
+    this->metrics.merge_compact_key_count_stats.update(result_size);
+  } else {
+    this->metrics.merge_compact_failures.add(1);
+  }
+
+#endif  // TURTLE_KV_PROFILE_UPDATES
+
+  return result_set;
 }
 
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/in_memory_leaf.cpp
+++ b/src/turtle_kv/tree/in_memory_leaf.cpp
@@ -160,6 +160,7 @@ Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
       << BATT_INSPECT(this->tree_options.flush_size());
 
   auto filter_bits_per_key = context.tree_options().filter_bits_per_key();
+  const bool overcommit_triggered = context.overcommit().is_triggered();
   llfs::PageSize filter_page_size = context.tree_options().filter_page_size();
 
   BATT_ASSIGN_OK_RESULT(
@@ -169,7 +170,7 @@ Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
           packed_leaf_page_layout_id(),
           llfs::LruPriority{kNewLeafLruPriority},
           /*task_count=*/2,
-          [this, filter_bits_per_key, filter_page_size](
+          [this, filter_bits_per_key, filter_page_size, overcommit_triggered](
               usize task_i,
               llfs::PageCache& page_cache,
               llfs::PageBuffer& page_buffer) -> StatusOr<TreeSerializeContext::PinPageToJobFn> {
@@ -185,6 +186,7 @@ Status InMemoryLeaf::start_serialize(TreeSerializeContext& context)
             BATT_CHECK_EQ(task_i, 1);
 
             return build_filter_for_leaf_in_job(page_cache,
+                                                overcommit_triggered,
                                                 filter_bits_per_key,
                                                 filter_page_size,
                                                 page_buffer.page_id(),

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -132,19 +132,25 @@ using PackedSegment = PackedUpdateBuffer::Segment;
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 /*static*/ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::from_subtrees(
-    llfs::PageLoader& page_loader,
+    BatchUpdateContext& update_context,
     const TreeOptions& tree_options,
     Subtree&& first_subtree,
     Subtree&& second_subtree,
     const KeyView& key_upper_bound,
     IsRoot is_root)
 {
+  llfs::PageLoader& page_loader = update_context.page_loader;
+  llfs::PageCacheOvercommit& overcommit = update_context.overcommit;
+
   auto new_node = std::make_unique<InMemoryNode>(llfs::PinnedPage{},
                                                  tree_options,
                                                  tree_options.is_size_tiered());
 
-  BATT_ASSIGN_OK_RESULT(const i32 first_height, first_subtree.get_height(page_loader));
-  BATT_ASSIGN_OK_RESULT(const i32 second_height, second_subtree.get_height(page_loader));
+  BATT_ASSIGN_OK_RESULT(const i32 first_height,  //
+                        first_subtree.get_height(page_loader, overcommit));
+
+  BATT_ASSIGN_OK_RESULT(const i32 second_height,  //
+                        second_subtree.get_height(page_loader, overcommit));
 
   BATT_CHECK_EQ(first_height, second_height);
 
@@ -160,23 +166,27 @@ using PackedSegment = PackedUpdateBuffer::Segment;
   if (is_root) {
     new_node->pivot_keys_[0] = global_min_key();
   } else {
-    BATT_ASSIGN_OK_RESULT(new_node->pivot_keys_[0],
-                          new_node->children[0].get_min_key(page_loader, new_node->child_pages[0]));
+    BATT_ASSIGN_OK_RESULT(
+        new_node->pivot_keys_[0],
+        new_node->children[0].get_min_key(page_loader, overcommit, new_node->child_pages[0]));
   }
 
-  BATT_ASSIGN_OK_RESULT(const KeyView first_child_max_key,
-                        new_node->children[0].get_max_key(page_loader, new_node->child_pages[0]));
+  BATT_ASSIGN_OK_RESULT(
+      const KeyView first_child_max_key,
+      new_node->children[0].get_max_key(page_loader, overcommit, new_node->child_pages[0]));
 
-  BATT_ASSIGN_OK_RESULT(const KeyView second_child_min_key,
-                        new_node->children[1].get_min_key(page_loader, new_node->child_pages[1]));
+  BATT_ASSIGN_OK_RESULT(
+      const KeyView second_child_min_key,
+      new_node->children[1].get_min_key(page_loader, overcommit, new_node->child_pages[1]));
 
   const KeyView prefix = llfs::find_common_prefix(0, first_child_max_key, second_child_min_key);
 
   new_node->pivot_keys_[1] = second_child_min_key.substr(0, prefix.size() + 1);
   new_node->pivot_keys_[2] = key_upper_bound;
 
-  BATT_ASSIGN_OK_RESULT(new_node->max_key_,
-                        new_node->children[1].get_max_key(page_loader, new_node->child_pages[1]));
+  BATT_ASSIGN_OK_RESULT(
+      new_node->max_key_,
+      new_node->children[1].get_max_key(page_loader, overcommit, new_node->child_pages[1]));
 
   return new_node;
 }
@@ -208,9 +218,7 @@ Status InMemoryNode::apply_batch_update(BatchUpdate& update,
 
   // Update per-pivot pending bytes.
   //
-  in_node(*this).update_pending_bytes(update.context.worker_pool,
-                                      update.result_set.get(),
-                                      PackedSizeOfEdit{});
+  in_node(*this).update_pending_bytes(update);
 
   // Merge the update batch into the buffer.
   //
@@ -293,7 +301,7 @@ Status InMemoryNode::update_buffer_insert(BatchUpdate& update)
           [&](MergeCompactor& compactor) -> Status {
             compactor.push_level(update.result_set.live_edit_slices());
             this->push_levels_to_merge(compactor,
-                                       update.context.page_loader,
+                                       update.context,
                                        segment_load_status,
                                        has_page_refs,
                                        levels_to_merge,
@@ -406,7 +414,7 @@ Status InMemoryNode::compact_update_buffer_levels(BatchUpdateContext& update_con
                             global_max_key(),
                             [&](MergeCompactor& compactor) -> Status {
                               this->push_levels_to_merge(compactor,
-                                                         update_context.page_loader,
+                                                         update_context,
                                                          segment_load_status,
                                                          has_page_refs,
                                                          as_slice(this->update_buffer.levels),
@@ -453,7 +461,7 @@ StatusOr<BatchUpdate> InMemoryNode::collect_pivot_batch(BatchUpdateContext& upda
           /*max_key=*/pivot_key_range.upper_bound,  //
           [&](MergeCompactor& compactor) -> Status {
             this->push_levels_to_merge(compactor,
-                                       update_context.page_loader,
+                                       update_context,
                                        segment_load_status,
                                        has_page_refs,
                                        as_slice(this->update_buffer.levels),
@@ -482,6 +490,10 @@ StatusOr<BatchUpdate> InMemoryNode::collect_pivot_batch(BatchUpdateContext& upda
 //
 Status InMemoryNode::flush_to_pivot(BatchUpdateContext& update_context, i32 pivot_i)
 {
+#if TURTLE_KV_PROFILE_UPDATES
+  update_context.metrics.flush_count.add(1);
+#endif  // TURTLE_KV_PROFILE_UPDATES
+
   Interval<KeyView> pivot_key_range = in_node(*this).get_pivot_key_range(pivot_i);
 
   BATT_ASSIGN_OK_RESULT(BatchUpdate child_update,
@@ -521,8 +533,7 @@ Status InMemoryNode::flush_to_pivot(BatchUpdateContext& update_context, i32 pivo
 
   // Mark all keys in the child update as flushed.
   //
-  BATT_REQUIRE_OK(
-      this->set_pivot_items_flushed(update_context.page_loader, pivot_i, flush_key_crange));
+  BATT_REQUIRE_OK(this->set_pivot_items_flushed(update_context, pivot_i, flush_key_crange));
 
   // Update pending bytes for the flushed pivot; this is equal to the number of bytes we had to trim
   // from the end of the batch to make it fit under the limit.
@@ -600,6 +611,10 @@ Status InMemoryNode::make_child_viable(BatchUpdateContext& update_context, i32 p
 //
 Status InMemoryNode::split_child(BatchUpdateContext& update_context, i32 pivot_i)
 {
+#if TURTLE_KV_PROFILE_UPDATES
+  update_context.metrics.split_count.add(1);
+#endif
+
   Subtree& child = this->children[pivot_i];
 
   StatusOr<Optional<Subtree>> status_or_sibling = child.try_split(update_context);
@@ -622,10 +637,14 @@ Status InMemoryNode::split_child(BatchUpdateContext& update_context, i32 pivot_i
   llfs::PinnedPage& sibling_page = this->child_pages[sibling_i];
 
   BATT_ASSIGN_OK_RESULT(const KeyView child_max_key,
-                        child.get_max_key(update_context.page_loader, child_page));
+                        child.get_max_key(update_context.page_loader,  //
+                                          update_context.overcommit,
+                                          child_page));
 
   BATT_ASSIGN_OK_RESULT(const KeyView sibling_min_key,
-                        sibling.get_min_key(update_context.page_loader, sibling_page));
+                        sibling.get_min_key(update_context.page_loader,  //
+                                            update_context.overcommit,
+                                            sibling_page));
 
   //----- --- -- -  -  -   -
   // Update update_buffer levels.  This comes first because we use u64-based bit sets for
@@ -644,7 +663,10 @@ Status InMemoryNode::split_child(BatchUpdateContext& update_context, i32 pivot_i
           return OkStatus();
         },
         [&](SegmentedLevel& segmented_level) -> Status {
-          return in_segmented_level(*this, segmented_level, update_context.page_loader)  //
+          return in_segmented_level(*this,
+                                    segmented_level,
+                                    update_context.page_loader,
+                                    update_context.overcommit)  //
               .split_pivot(pivot_i, pivot_key_range, sibling_min_key);
         }));
   }
@@ -693,7 +715,7 @@ Status InMemoryNode::split_child(BatchUpdateContext& update_context, i32 pivot_i
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-Status InMemoryNode::set_pivot_items_flushed(llfs::PageLoader& page_loader,
+Status InMemoryNode::set_pivot_items_flushed(BatchUpdateContext& update_context,
                                              usize pivot_i,
                                              const CInterval<KeyView>& flush_key_crange)
 {
@@ -719,7 +741,10 @@ Status InMemoryNode::set_pivot_items_flushed(llfs::PageLoader& page_loader,
         },
         [&](SegmentedLevel& segmented_level) {
           segment_load_status.Update(
-              in_segmented_level(*this, segmented_level, page_loader)
+              in_segmented_level(*this,
+                                 segmented_level,
+                                 update_context.page_loader,
+                                 update_context.overcommit)
                   .flush_pivot_up_to_key(pivot_i, flush_key_crange.upper_bound));
 
           is_now_empty = segmented_level.empty();
@@ -825,7 +850,7 @@ MaxPendingBytes InMemoryNode::find_max_pending() const
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 void InMemoryNode::push_levels_to_merge(MergeCompactor& compactor,
-                                        llfs::PageLoader& page_loader,
+                                        BatchUpdateContext& update_context,
                                         Status& segment_load_status,
                                         HasPageRefs& has_page_refs,
                                         const Slice<Level>& levels_to_merge,
@@ -855,8 +880,9 @@ void InMemoryNode::push_levels_to_merge(MergeCompactor& compactor,
           return SegmentedLevelScanner<const InMemoryNode, const SegmentedLevel, llfs::PageLoader>{
                      *this,
                      segmented_level,
-                     page_loader,
+                     update_context.page_loader,
                      llfs::PinPageToJob::kDefault,
+                     update_context.overcommit,
                      segment_load_status,
                      min_pivot_i,
                      min_key}  //
@@ -933,13 +959,16 @@ SubtreeViability InMemoryNode::get_viability() const
 {
   NeedsSplit needs_split;
 
-  const usize variable_space = sizeof(PackedNodePage::key_and_flushed_item_data_);
+  const usize variable_space = PackedNodePage::variable_data_space();
   const usize keys_size = this->key_data_byte_size();
   const usize counts_size = this->flushed_item_counts_byte_size();
   const bool variables_too_large = (keys_size + counts_size) > variable_space;
 
-  needs_split.too_many_pivots = (this->pivot_count() > this->max_pivot_count());
-  needs_split.too_many_segments = (this->segment_count() > this->max_segment_count());
+  needs_split.pivot_count = BATT_CHECKED_CAST(u16, this->pivot_count());
+  needs_split.segment_count = BATT_CHECKED_CAST(u16, this->segment_count());
+  needs_split.height = BATT_CHECKED_CAST(i16, this->height);
+  needs_split.too_many_pivots = (needs_split.pivot_count > this->max_pivot_count());
+  needs_split.too_many_segments = (needs_split.segment_count > this->max_segment_count());
   needs_split.keys_too_large = (keys_size > variable_space);
   needs_split.flushed_item_counts_too_large = (counts_size != 0 && variables_too_large);
 
@@ -979,6 +1008,83 @@ bool InMemoryNode::is_viable(IsRoot is_root) const
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split(BatchUpdateContext& context)
+{
+  bool tried_compacting_levels = false;
+  usize normal_flush_count = 0;
+
+  for (;;) {
+    StatusOr<std::unique_ptr<InMemoryNode>> upper_half = this->try_split_direct(context);
+    if (upper_half.ok() || upper_half.status() != batt::StatusCode::kInternal) {
+      return upper_half;
+    }
+
+    // Check to see whether various fixes might avoid the failure to split...
+    //
+    SubtreeViability viability = this->get_viability();
+
+    // If the only thing preventing us from splitting the node is related to there being a lot
+    // of segments/levels, then we can try fixing this by re-compacting the entire update
+    // buffer.
+    //
+    if (compacting_levels_might_fix(viability) && !tried_compacting_levels &&
+        this->update_buffer.count_non_empty_levels() > 1) {
+      BATT_REQUIRE_OK(this->compact_update_buffer_levels(context));
+      tried_compacting_levels = true;
+      continue;
+    }
+
+    // If we need to reduce the number of levels, and there is enough pending update data to
+    // reflush to the most recently flushed pivot, then try doing that.
+    //
+    {
+      // The reason we are only considering the latest pivot to be flushed is that we are
+      // probably inside try_split because of another flush, and we don't want to deal with any
+      // issues arising from two splits (i.e., different pivots) at once.
+      //
+      const i32 reflush_pivot_i = this->latest_flush_pivot_i_.value_or((i32)this->pivot_count());
+
+      const bool recently_flushed = reflush_pivot_i < (i32)this->pivot_count();
+
+      const bool can_reflush = recently_flushed && (this->pending_bytes[reflush_pivot_i] >=
+                                                    this->tree_options.min_flush_size());
+      if (can_reflush) {
+        BATT_REQUIRE_OK(this->flush_to_pivot(context, reflush_pivot_i));
+        continue;
+      }
+    }
+
+    // If max flush factor is >1 and we are at the bottom of the tree, then we can attempt a normal
+    // flush, so long as the number of pivots is under the split limit.
+    //
+    if (this->tree_options.max_flush_factor() > 1 && normal_flush_count < this->pivot_count() &&
+        normal_flush_might_fix(viability)) {
+      Optional<i32> saved_pivot_i = this->latest_flush_pivot_i_;
+      this->latest_flush_pivot_i_ = None;
+      Status flush_status = this->flush_if_necessary(context);
+      if (flush_status.ok() && this->latest_flush_pivot_i_) {
+        ++normal_flush_count;
+        continue;
+      }
+      this->latest_flush_pivot_i_ = saved_pivot_i;
+    }
+
+    LOG(ERROR) << "Failed to split node;" << BATT_INSPECT(this->tree_options.flush_size())
+               << BATT_INSPECT(this->tree_options.min_flush_size())
+               << BATT_INSPECT(this->tree_options.max_flush_size())
+               << BATT_INSPECT(this->update_buffer.levels.size()) << BATT_INSPECT(viability) << "\n"
+               << BATT_INSPECT_RANGE(this->pending_bytes) << "\n"
+               << BATT_INSPECT(compacting_levels_might_fix(viability)) << "\n"
+               << BATT_INSPECT(normal_flush_might_fix(viability)) << "\n"
+               << boost::stacktrace::stacktrace{};
+
+    return upper_half;
+  }
+  BATT_UNREACHABLE();
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpdateContext& context)
 {
   const SubtreeViability orig_viability = this->get_viability();
 
@@ -1028,59 +1134,6 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split(BatchUpdateConte
     // If we ever try the same split point a second time, fail.
     //
     if (get_bit(tried_already, split_pivot_i)) {
-      // Reset this node to its original state before trying one last thing...
-      {
-        auto reset_now = std::move(reset_this_on_failure);
-      }
-
-      // Check to see whether various fixes might avoid the failure to split...
-      //
-      bool retry_split = false;
-
-      // If the only thing preventing us from splitting the node is related to there being a lot
-      // of segments/levels, then we can try fixing this by re-compacting the entire update
-      // buffer.
-      //
-      if (!retry_split && compacting_levels_might_fix(this->get_viability()) &&
-          this->update_buffer.count_non_empty_levels() > 1) {
-        BATT_REQUIRE_OK(this->compact_update_buffer_levels(context));
-        retry_split = true;
-      }
-
-      // If we need to reduce the number of levels, and there is enough pending update data to
-      // reflush to the most recently flushed pivot, then try doing that.
-      //
-      if (!retry_split) {
-        // The reason we are only considering the latest pivot to be flushed is that we are
-        // probably inside try_split because of another flush, and we don't want to deal with any
-        // issues arising from two splits (i.e., different pivots) at once.
-        //
-        const i32 reflush_pivot_i = this->latest_flush_pivot_i_.value_or((i32)this->pivot_count());
-
-        const bool recently_flushed = reflush_pivot_i < (i32)this->pivot_count();
-
-        const bool can_reflush = recently_flushed && (this->pending_bytes[reflush_pivot_i] >=
-                                                      this->tree_options.min_flush_size());
-        if (can_reflush) {
-          BATT_REQUIRE_OK(this->flush_to_pivot(context, reflush_pivot_i));
-          retry_split = true;
-        }
-      }
-
-      if (retry_split) {
-        return this->try_split(context);
-      }
-
-      LOG(ERROR) << "Failed to split node;" << BATT_INSPECT(orig_pivot_count)
-                 << BATT_INSPECT(this->tree_options.flush_size())
-                 << BATT_INSPECT(this->tree_options.min_flush_size())
-                 << BATT_INSPECT(this->tree_options.max_flush_size())
-                 << BATT_INSPECT(this->update_buffer.levels.size())
-                 << BATT_INSPECT(this->get_viability()) << BATT_INSPECT(orig_viability) << "\n"
-                 << BATT_INSPECT(lower_viability) << BATT_INSPECT(upper_viability) << "\n"
-                 << BATT_INSPECT_RANGE(orig_pending_bytes) << "\n"
-                 << boost::stacktrace::stacktrace{};
-
       return {batt::StatusCode::kInternal};
     }
     tried_already = set_bit(tried_already, split_pivot_i, true);
@@ -1131,6 +1184,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split(BatchUpdateConte
     BATT_ASSIGN_OK_RESULT(
         node_lower_half->max_key_,
         node_lower_half->children.back().get_max_key(context.page_loader,
+                                                     context.overcommit,
                                                      node_lower_half->child_pages.back()));
 
     node_lower_half->common_key_prefix = "";  // TODO [tastolfi 2025-03-17]
@@ -1255,7 +1309,7 @@ StatusOr<ValueView> InMemoryNode::find_key_in_level(usize level_i,
         return merged_level.result_set.find_key(query.key());
       },
       [&](const SegmentedLevel& segmented_level) -> StatusOr<ValueView> {
-        return in_segmented_level(*this, segmented_level, *query.page_loader)
+        return in_segmented_level(*this, segmented_level, *query.page_loader, query.overcommit())
             .find_key(key_pivot_i, query);
       });
 }
@@ -1284,7 +1338,7 @@ bool InMemoryNode::is_packable() const
 Status InMemoryNode::start_serialize(TreeSerializeContext& context)
 {
   BATT_CHECK(!batt::is_case<NeedsSplit>(this->get_viability()))
-      << BATT_INSPECT(this->get_viability());
+      << BATT_INSPECT(this->get_viability()) << BATT_INSPECT(this->pivot_count());
 
   usize total_segments = 0;
 
@@ -1320,7 +1374,11 @@ Status InMemoryNode::start_serialize(TreeSerializeContext& context)
 //
 StatusOr<llfs::PageId> InMemoryNode::finish_serialize(TreeSerializeContext& context)
 {
-  Self::metrics().level_depth_stats.update(this->update_buffer.levels.size());
+  static Metrics& r_metrics = Self::metrics();
+  //----- --- -- -  -  -   -
+  r_metrics.serialized_node_count.add(1);
+  r_metrics.serialized_pivot_count.add(this->pivot_count());
+  r_metrics.level_depth_stats.update(this->update_buffer.levels.size());
 
   for (Level& level : this->update_buffer.levels) {
     Optional<SegmentedLevel> new_segmented_level;
@@ -1332,13 +1390,17 @@ StatusOr<llfs::PageId> InMemoryNode::finish_serialize(TreeSerializeContext& cont
               return OkStatus();
             },
             [this, &context, &new_segmented_level](MergedLevel& merged_level) -> Status {
+              r_metrics.serialized_nonempty_level_count.add(1);
               StatusOr<SegmentedLevel> result = merged_level.finish_serialize(*this, context);
               if (result.ok()) {
                 new_segmented_level.emplace(std::move(*result));
+                r_metrics.serialized_buffer_segment_count.add(result->segment_count());
               }
               return result.status();
             },
             [](const SegmentedLevel& segmented_level) -> Status {
+              r_metrics.serialized_nonempty_level_count.add(1);
+              r_metrics.serialized_buffer_segment_count.add(segmented_level.segment_count());
               return OkStatus();
             }));
 
@@ -1361,6 +1423,7 @@ StatusOr<llfs::PageId> InMemoryNode::finish_serialize(TreeSerializeContext& cont
   StatusOr<std::shared_ptr<llfs::PageBuffer>> node_page_buffer =
       context.page_job().new_page(this->tree_options.node_size(),
                                   batt::WaitForResource::kTrue,
+                                  context.overcommit(),
                                   NodePageView::page_layout_id(),
                                   llfs::LruPriority{kNewNodeLruPriority},
                                   /*callers=*/0,
@@ -1388,7 +1451,8 @@ StatusOr<llfs::PageId> InMemoryNode::finish_serialize(TreeSerializeContext& cont
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 StatusOr<llfs::PinnedPage> Segment::load_leaf_page(llfs::PageLoader& page_loader,
-                                                   llfs::PinPageToJob pin_page_to_job) const
+                                                   llfs::PinPageToJob pin_page_to_job,
+                                                   llfs::PageCacheOvercommit& overcommit) const
 {
   return this->page_id_slot.load_through(page_loader,
                                          llfs::PageLoadOptions{
@@ -1396,6 +1460,7 @@ StatusOr<llfs::PinnedPage> Segment::load_leaf_page(llfs::PageLoader& page_loader
                                              pin_page_to_job,
                                              llfs::OkIfNotFound{false},
                                              llfs::LruPriority{kLeafLruPriority},
+                                             overcommit,
                                          });
 }
 
@@ -1415,6 +1480,7 @@ StatusOr<usize> MergedLevel::start_serialize(const InMemoryNode& node,
   BATT_CHECK_EQ(running_total.back() - running_total.front(), this->result_set.get_packed_size());
 
   auto filter_bits_per_key = context.tree_options().filter_bits_per_key();
+  const bool overcommit_triggered = context.overcommit().is_triggered();
   llfs::PageSize filter_page_size = context.tree_options().filter_page_size();
 
   for (const Interval<usize>& part_extents : page_parts) {
@@ -1425,7 +1491,7 @@ StatusOr<usize> MergedLevel::start_serialize(const InMemoryNode& node,
             packed_leaf_page_layout_id(),
             llfs::LruPriority{kNewLeafLruPriority},
             /*task_count=*/2,
-            [this, &node, part_extents, filter_bits_per_key, filter_page_size](
+            [this, &node, part_extents, filter_bits_per_key, overcommit_triggered, filter_page_size](
                 usize task_i,
                 llfs::PageCache& page_cache,
                 llfs::PageBuffer& page_buffer) -> TreeSerializeContext::PinPageToJobFn {
@@ -1441,6 +1507,7 @@ StatusOr<usize> MergedLevel::start_serialize(const InMemoryNode& node,
               BATT_CHECK_EQ(task_i, 1);
 
               return build_filter_for_leaf_in_job(page_cache,
+                                                  overcommit_triggered,
                                                   filter_bits_per_key,
                                                   filter_page_size,
                                                   page_buffer.page_id(),
@@ -1564,7 +1631,9 @@ void InMemoryNode::UpdateBuffer::SegmentedLevel::check_items_sorted(
       node,
       *this,
       page_loader,
-      llfs::PinPageToJob::kDefault};
+      llfs::PinPageToJob::kDefault,
+      llfs::PageCacheOvercommit::not_allowed(),
+  };
 
   Optional<std::string> prev_slice_max_key;
   usize item_i = 0;

--- a/src/turtle_kv/tree/in_memory_node.test.cpp
+++ b/src/turtle_kv/tree/in_memory_node.test.cpp
@@ -60,6 +60,7 @@ using turtle_kv::NeedsSplit;
 using turtle_kv::None;
 using turtle_kv::OkStatus;
 using turtle_kv::Optional;
+using turtle_kv::PageSliceStorage;
 using turtle_kv::ParentNodeHeight;
 using turtle_kv::PinningPageLoader;
 using turtle_kv::Slice;
@@ -365,6 +366,8 @@ void SubtreeBatchUpdateScenario::run()
 
   usize total_items = 0;
 
+  turtle_kv::BatchUpdateMetrics metrics;
+
   for (usize i = 0; i < max_i; ++i) {
     BatchUpdate update{
         .context =
@@ -372,6 +375,8 @@ void SubtreeBatchUpdateScenario::run()
                 .worker_pool = worker_pool,
                 .page_loader = *page_loader,
                 .cancel_token = batt::CancelToken{},
+                .metrics = metrics,
+                .overcommit = llfs::PageCacheOvercommit::not_allowed(),
             },
         .result_set = result_set_generator(DecayToItem<false>{}, rng, strings),
         .edit_size_totals = None,
@@ -386,7 +391,8 @@ void SubtreeBatchUpdateScenario::run()
     Status table_update_status = update_table(expected_table, update.result_set);
     ASSERT_TRUE(table_update_status.ok()) << BATT_INSPECT(table_update_status);
 
-    StatusOr<i32> tree_height = tree.get_height(*page_loader);
+    StatusOr<i32> tree_height =
+        tree.get_height(*page_loader, llfs::PageCacheOvercommit::not_allowed());
     ASSERT_TRUE(tree_height.ok()) << BATT_INSPECT(tree_height);
 
     Status status =  //
@@ -415,7 +421,12 @@ void SubtreeBatchUpdateScenario::run()
       }
 
       std::unique_ptr<llfs::PageCacheJob> page_job = page_cache->new_job();
-      TreeSerializeContext context{tree_options, *page_job, worker_pool};
+      TreeSerializeContext context{
+          tree_options,
+          *page_job,
+          worker_pool,
+          llfs::PageCacheOvercommit::not_allowed(),
+      };
 
       Status start_status = tree.start_serialize(context);
       ASSERT_TRUE(start_status.ok()) << BATT_INSPECT(start_status);
@@ -446,12 +457,16 @@ void SubtreeBatchUpdateScenario::run()
         std::array<std::pair<KeyView, ValueView>, kMaxScanSize> scan_items_buffer;
         KeyView min_key = update.result_set.get_min_key();
 
-        KVStoreScanner kv_scanner{*page_loader,
-                                  root_ptr->page_id_slot_or_panic(),
-                                  BATT_OK_RESULT_OR_PANIC(root_ptr->get_height(*page_loader)),
-                                  min_key,
-                                  tree_options.trie_index_sharded_view_size(),
-                                  None};
+        PageSliceStorage page_slice_storage;
+
+        KVStoreScanner kv_scanner{
+            *page_loader,
+            root_ptr->page_id_slot_or_panic(),
+            BATT_OK_RESULT_OR_PANIC(root_ptr->get_height(*page_loader,  //
+                                                         llfs::PageCacheOvercommit::not_allowed())),
+            min_key,
+            tree_options.trie_index_sharded_view_size(),
+            &page_slice_storage};
 
         usize n_read = 0;
         {

--- a/src/turtle_kv/tree/key_query.hpp
+++ b/src/turtle_kv/tree/key_query.hpp
@@ -149,7 +149,9 @@ struct KeyQuery {
   BoolStatus reject_page(llfs::PageId page_id_to_reject [[maybe_unused]],
                          const Optional<llfs::PageId>& filter_page_id)
   {
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{Every2ToTheConst<16>{}, Self::metrics().reject_page_latency};
+#endif
 
     Self::metrics().total_filter_query_count.add(1);
 
@@ -249,6 +251,13 @@ struct KeyQuery {
   BoolStatus reject_page(llfs::PageId page_id_to_reject)
   {
     return this->reject_page(page_id_to_reject, this->filter_page_id_for(page_id_to_reject));
+  }
+
+  /** \brief Always disallows cache overcommit; this is where we would change this for queries.
+   */
+  llfs::PageCacheOvercommit& overcommit() const
+  {
+    return llfs::PageCacheOvercommit::not_allowed();
   }
 };
 

--- a/src/turtle_kv/tree/packed_node_page.cpp
+++ b/src/turtle_kv/tree/packed_node_page.cpp
@@ -208,14 +208,16 @@ StatusOr<ValueView> PackedNodePage::find_key_in_level(usize level_i,
   UpdateBuffer::SegmentedLevel level =
       this->is_size_tiered() ? this->get_tier(level_i) : this->get_level(level_i);
 
-  return in_segmented_level(*this, level, *query.page_loader).find_key(key_pivot_i, query);
+  return in_segmented_level(*this, level, *query.page_loader, query.overcommit())
+      .find_key(key_pivot_i, query);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 StatusOr<llfs::PinnedPage> PackedNodePage::UpdateBuffer::Segment::load_leaf_page(
     llfs::PageLoader& page_loader,
-    llfs::PinPageToJob pin_page_to_job) const
+    llfs::PinPageToJob pin_page_to_job,
+    llfs::PageCacheOvercommit& overcommit) const
 {
   return page_loader.load_page(this->leaf_page_id.unpack(),
                                llfs::PageLoadOptions{
@@ -223,6 +225,7 @@ StatusOr<llfs::PinnedPage> PackedNodePage::UpdateBuffer::Segment::load_leaf_page
                                    pin_page_to_job,
                                    llfs::OkIfNotFound{false},
                                    llfs::LruPriority{kLeafLruPriority},
+                                   overcommit,
                                });
 }
 

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -146,7 +146,8 @@ struct PackedNodePage {
       }
 
       StatusOr<llfs::PinnedPage> load_leaf_page(llfs::PageLoader& page_loader,
-                                                llfs::PinPageToJob pin_page_to_job) const;
+                                                llfs::PinPageToJob pin_page_to_job,
+                                                llfs::PageCacheOvercommit& overcommit) const;
 
       usize get_flushed_item_upper_bound(const SegmentedLevel& level, i32 pivot_i) const;
     };
@@ -242,6 +243,11 @@ struct PackedNodePage {
     BATT_ASSERT_LE(packed_node_page.pivot_count(), 64);
 
     return packed_node_page;
+  }
+
+  static usize variable_data_space()
+  {
+    return sizeof(PackedNodePage::key_and_flushed_item_data_);
   }
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/turtle_kv/tree/pinning_page_loader.hpp
+++ b/src/turtle_kv/tree/pinning_page_loader.hpp
@@ -87,7 +87,9 @@ class PinningPageLoader : public llfs::PageLoader
   //
   void prefetch_hint(llfs::PageId page_id) override
   {
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{Every2ToTheConst<16>{}, this->metrics_.prefetch_hint_latency};
+#endif
     this->base_loader_.prefetch_hint(page_id);
   }
 
@@ -103,7 +105,9 @@ class PinningPageLoader : public llfs::PageLoader
       return found_in_hash_map;
     }
 
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{Every2ToTheConst<16>{}, this->metrics_.try_pin_from_cache_latency};
+#endif
     StatusOr<llfs::PinnedPage> pinned_page =
         this->base_loader_.try_pin_cached_page(page_id, options);
     timer.stop();
@@ -127,7 +131,9 @@ class PinningPageLoader : public llfs::PageLoader
       return found_in_hash_map;
     }
 
+#if TURTLE_KV_PROFILE_QUERIES
     LatencyTimer timer{Every2ToTheConst<16>{}, this->metrics_.get_page_from_cache_latency};
+#endif
     StatusOr<llfs::PinnedPage> pinned_page = this->base_loader_.load_page(page_id, options);
     timer.stop();
 

--- a/src/turtle_kv/tree/segmented_level_scanner.test.cpp
+++ b/src/turtle_kv/tree/segmented_level_scanner.test.cpp
@@ -187,7 +187,9 @@ class SegmentedLevelScannerTest : public ::testing::Test
             actual,
             actual.level_,
             *this->fake_page_loader,
-            llfs::PinPageToJob::kDefault};
+            llfs::PinPageToJob::kDefault,
+            llfs::PageCacheOvercommit::not_allowed(),
+        };
 
         std::move(scanner) | seq::for_each([&](const EditSlice& edit_slice) {
           batt::case_of(   //
@@ -222,6 +224,7 @@ class SegmentedLevelScannerTest : public ::testing::Test
                 actual.level_,
                 *this->fake_page_loader,
                 llfs::PinPageToJob::kDefault,
+                llfs::PageCacheOvercommit::not_allowed(),
                 /*min_pivot=*/pivot_i};
 
             std::move(scanner2) | seq::for_each([&](const EditSlice& edit_slice) {
@@ -393,7 +396,10 @@ void SegmentedLevelScannerTest::Scenario::run_with_pivot_count(usize pivot_count
     KeyView min_key_to_flush = min_unflushed_key[pivot_i];
     KeyView max_key_to_flush = get_key(*std::prev(flush_end));
 
-    Status flush_status = in_segmented_level(fake_node, fake_node.level_, *this->fake_page_loader)
+    Status flush_status = in_segmented_level(fake_node,
+                                             fake_node.level_,
+                                             *this->fake_page_loader,
+                                             llfs::PageCacheOvercommit::not_allowed())
                               .flush_pivot_up_to_key(pivot_i, max_key_to_flush);
 
     ASSERT_TRUE(flush_status.ok()) << BATT_INSPECT(flush_status);

--- a/src/turtle_kv/tree/storage_config.cpp
+++ b/src/turtle_kv/tree/storage_config.cpp
@@ -18,7 +18,10 @@ llfs::PageCacheOptions page_cache_options_from(const TreeOptions& tree_options,
   std::set<llfs::PageSize> sharded_leaf_views;
 
   sharded_leaf_views.insert(llfs::PageSize{4 * kKiB});
-  sharded_leaf_views.insert(tree_options.trie_index_sharded_view_size());
+
+  if (tree_options.trie_index_reserve_size() != 0) {
+    sharded_leaf_views.insert(tree_options.trie_index_sharded_view_size());
+  }
 
   for (llfs::PageSize view_size : sharded_leaf_views) {
     if (tree_options.leaf_size() != view_size) {

--- a/src/turtle_kv/tree/subtree.cpp
+++ b/src/turtle_kv/tree/subtree.cpp
@@ -231,8 +231,7 @@ Status Subtree::apply_batch_update(const TreeOptions& tree_options,
         [&](NeedsSplit needs_split) {
           // TODO [vsilai 2025-12-09]: revist when VLDB changes are merged in.
           //
-          if (needs_split.too_many_segments && !needs_split.too_many_pivots &&
-              !needs_split.keys_too_large) {
+          if (normal_flush_might_fix_root(needs_split)) {
             Status flush_status = new_subtree->try_flush(update.context);
             if (flush_status.ok() && batt::is_case<Viable>(new_subtree->get_viability())) {
               return OkStatus();

--- a/src/turtle_kv/tree/subtree.hpp
+++ b/src/turtle_kv/tree/subtree.hpp
@@ -104,16 +104,19 @@ class Subtree
 
   /** \brief Returns the current height of the tree.
    */
-  StatusOr<i32> get_height(llfs::PageLoader& page_loader) const;
+  StatusOr<i32> get_height(llfs::PageLoader& page_loader,
+                           llfs::PageCacheOvercommit& overcommit) const;
 
   /** \brief Returns the min-ordered key in the range of this subtree.
    */
   StatusOr<KeyView> get_min_key(llfs::PageLoader& page_loader,
+                                llfs::PageCacheOvercommit& overcommit,
                                 llfs::PinnedPage& pinned_page_out) const;
 
   /** \brief Returns the max-ordered key in the range of this subtree.
    */
   StatusOr<KeyView> get_max_key(llfs::PageLoader& page_loader,
+                                llfs::PageCacheOvercommit& overcommit,
                                 llfs::PinnedPage& pinned_page_out) const;
 
   /** \brief Evaluates whether this Subtree is viable to be serialized in its present state.  This

--- a/src/turtle_kv/tree/subtree_table.hpp
+++ b/src/turtle_kv/tree/subtree_table.hpp
@@ -28,7 +28,9 @@ class SubtreeTable : public Table
 
   StatusOr<ValueView> get(const KeyView& key) override
   {
-    BATT_ASSIGN_OK_RESULT(i32 height, this->subtree_.get_height(this->page_loader_));
+    BATT_ASSIGN_OK_RESULT(
+        i32 height,
+        this->subtree_.get_height(this->page_loader_, llfs::PageCacheOvercommit::not_allowed()));
 
     this->page_slice_storage_.emplace();
 

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -116,6 +116,9 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
+/** \brief If a node at height == 2 needs to be split (i.e., too large), and the reason is that the
+ * update buffer is too large
+ */
 inline bool normal_flush_might_fix(const SubtreeViability& viability)
 {
   return batt::case_of(
@@ -133,6 +136,25 @@ inline bool normal_flush_might_fix(const SubtreeViability& viability)
                !needs_split.items_too_large &&             //
                !needs_split.keys_too_large &&              //
                !needs_split.too_many_pivots;
+      });
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+inline bool normal_flush_might_fix_root(const SubtreeViability& viability)
+{
+  return batt::case_of(
+      viability,
+      [](const Viable&) {
+        return false;
+      },
+      [](const NeedsMerge&) {
+        return false;
+      },
+      [](const NeedsSplit& needs_split) {
+        return needs_split.too_many_segments &&  //
+               !needs_split.too_many_pivots &&   //
+               !needs_split.keys_too_large;
       });
 }
 

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -44,6 +44,11 @@ inline std::ostream& operator<<(std::ostream& out, const NeedsMerge& t)
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
 struct NeedsSplit {
+  u16 pivot_count = 0;
+  u16 segment_count = 0;
+  i16 height = 0;
+  u8 pad_[1];
+
   bool items_too_large : 1 = false;
   bool keys_too_large : 1 = false;
   bool too_many_pivots : 1 = false;
@@ -62,13 +67,14 @@ struct NeedsSplit {
   }
 };
 
-BATT_STATIC_ASSERT_EQ(sizeof(NeedsSplit), 1);
+BATT_STATIC_ASSERT_EQ(sizeof(NeedsSplit), 8);
 
 inline std::ostream& operator<<(std::ostream& out, const NeedsSplit& t)
 {
   return out << "NeedsSplit{.items_too_large=" << t.items_too_large
              << ", .keys_too_large=" << t.keys_too_large
-             << ", .too_many_pivots=" << t.too_many_pivots
+             << ", .too_many_pivots=" << t.too_many_pivots << ", .pivot_count=" << t.pivot_count
+             << ", .segment_count=" << t.segment_count << ", .height=" << t.height
              << ", .too_many_segments=" << t.too_many_segments
              << ", .flushed_item_counts_too_large=" << t.flushed_item_counts_too_large << ",}";
 }
@@ -104,6 +110,28 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
                 needs_split.too_many_segments) &&             //
                !needs_split.items_too_large &&                //
                !needs_split.keys_too_large &&                 //
+               !needs_split.too_many_pivots;
+      });
+}
+
+//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
+//
+inline bool normal_flush_might_fix(const SubtreeViability& viability)
+{
+  return batt::case_of(
+      viability,
+      [](const Viable&) {
+        return false;
+      },
+      [](const NeedsMerge&) {
+        return false;
+      },
+      [](const NeedsSplit& needs_split) {
+        return needs_split.height == 2 &&                  //
+               (needs_split.flushed_item_counts_too_large  //
+                || needs_split.too_many_segments) &&       //
+               !needs_split.items_too_large &&             //
+               !needs_split.keys_too_large &&              //
                !needs_split.too_many_pivots;
       });
 }

--- a/src/turtle_kv/tree/testing/fake_segment.hpp
+++ b/src/turtle_kv/tree/testing/fake_segment.hpp
@@ -26,10 +26,15 @@ struct FakeSegment {
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
   StatusOr<FakePinnedPage> load_leaf_page(FakePageLoader& loader,
-                                          llfs::PinPageToJob pin_page_to_job) const
+                                          llfs::PinPageToJob pin_page_to_job,
+                                          llfs::PageCacheOvercommit& overcommit) const
   {
     return loader.load_page(this->page_id_,
-                            llfs::PageLoadOptions{pin_page_to_job, llfs::OkIfNotFound{false}});
+                            llfs::PageLoadOptions{
+                                pin_page_to_job,
+                                llfs::OkIfNotFound{false},
+                                overcommit,
+                            });
   }
 
   u64 get_active_pivots() const

--- a/src/turtle_kv/tree/tree_options.hpp
+++ b/src/turtle_kv/tree/tree_options.hpp
@@ -289,6 +289,9 @@ class TreeOptions
     if (BATT_HINT_TRUE(this->trie_index_reserve_size_)) {
       return *this->trie_index_reserve_size_;
     }
+    if (this->leaf_size() < 128 * kKiB) {
+      return 0;
+    }
     if (this->key_size_hint() > 16) {
       return ((this->expected_items_per_leaf() * this->key_size_hint() + 15) / 16) * 5 / 8;
     }

--- a/src/turtle_kv/tree/tree_serialize_context.cpp
+++ b/src/turtle_kv/tree/tree_serialize_context.cpp
@@ -7,12 +7,15 @@ using BuildPageJobId = TreeSerializeContext::BuildPageJobId;
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
-/*explicit*/ TreeSerializeContext::TreeSerializeContext(const TreeOptions& tree_options,
-                                                        llfs::PageCacheJob& page_job,
-                                                        batt::WorkerPool& worker_pool) noexcept
+/*explicit*/ TreeSerializeContext::TreeSerializeContext(
+    const TreeOptions& tree_options,
+    llfs::PageCacheJob& page_job,
+    batt::WorkerPool& worker_pool,
+    llfs::PageCacheOvercommit& overcommit) noexcept
     : tree_options_{tree_options}
     , page_job_{page_job}
     , worker_pool_{worker_pool}
+    , overcommit_{overcommit}
 {
 }
 
@@ -83,6 +86,7 @@ Status TreeSerializeContext::build_all_pages()
       StatusOr<std::shared_ptr<llfs::PageBuffer>> page_buffer =
           this->page_job_.new_page(build.page_size,
                                    batt::WaitForResource::kTrue,
+                                   this->overcommit_,
                                    build.page_layout_id,
                                    build.lru_priority,
                                    /*callers=*/0,

--- a/src/turtle_kv/tree/tree_serialize_context.hpp
+++ b/src/turtle_kv/tree/tree_serialize_context.hpp
@@ -88,7 +88,8 @@ class TreeSerializeContext
 
   explicit TreeSerializeContext(const TreeOptions& tree_options,
                                 llfs::PageCacheJob& page_job,
-                                batt::WorkerPool& worker_pool) noexcept;
+                                batt::WorkerPool& worker_pool,
+                                llfs::PageCacheOvercommit& overcommit) noexcept;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -105,6 +106,11 @@ class TreeSerializeContext
   batt::WorkerPool& worker_pool()
   {
     return this->worker_pool_;
+  }
+
+  llfs::PageCacheOvercommit& overcommit()
+  {
+    return this->overcommit_;
   }
 
   const batt::CancelToken& cancel_token() const
@@ -133,6 +139,8 @@ class TreeSerializeContext
   llfs::PageCacheJob& page_job_;
 
   batt::WorkerPool& worker_pool_;
+
+  llfs::PageCacheOvercommit& overcommit_;
 
   batt::CancelToken cancel_token_;
 

--- a/src/turtle_kv/tree/visit_tree_page.hpp
+++ b/src/turtle_kv/tree/visit_tree_page.hpp
@@ -28,6 +28,7 @@ template <
 StatusOr<R> visit_tree_page(llfs::PageLoader& page_loader,
                             llfs::PinnedPage& pinned_page_out,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   if (!pinned_page_out || pinned_page_out.page_id() != page_id_slot.page_id) {
@@ -37,6 +38,7 @@ StatusOr<R> visit_tree_page(llfs::PageLoader& page_loader,
                                                         llfs::PinPageToJob::kDefault,
                                                         llfs::OkIfNotFound{false},
                                                         llfs::LruPriority{kNodeLruPriority},
+                                                        overcommit,
                                                     }));
   }
   const auto& page_header =
@@ -60,11 +62,16 @@ template <
     typename R = StatusOr<RemoveStatusOr<std::invoke_result_t<VisitorFn, const PackedLeafPage&>>>>
 StatusOr<R> visit_tree_page(llfs::PageLoader& page_loader,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   llfs::PinnedPage pinned_page;
 
-  return visit_tree_page(page_loader, pinned_page, page_id_slot, BATT_FORWARD(visitor_fn));
+  return visit_tree_page(page_loader,
+                         pinned_page,
+                         page_id_slot,
+                         overcommit,
+                         BATT_FORWARD(visitor_fn));
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -73,11 +80,13 @@ template <typename... CaseFns>
 decltype(auto) visit_tree_page(llfs::PageLoader& page_loader,
                                llfs::PinnedPage& pinned_page_out,
                                const llfs::PageIdSlot& page_id_slot,
+                               llfs::PageCacheOvercommit& overcommit,
                                CaseFns&&... case_fns)
 {
   return visit_tree_page(page_loader,
                          pinned_page_out,
                          page_id_slot,
+                         overcommit,
                          batt::make_case_of_visitor(BATT_FORWARD(case_fns)...));
 }
 
@@ -86,10 +95,12 @@ decltype(auto) visit_tree_page(llfs::PageLoader& page_loader,
 template <typename... CaseFns>
 decltype(auto) visit_tree_page(llfs::PageLoader& page_loader,
                                const llfs::PageIdSlot& page_id_slot,
+                               llfs::PageCacheOvercommit& overcommit,
                                CaseFns&&... case_fns)
 {
   return visit_tree_page(page_loader,
                          page_id_slot,
+                         overcommit,
                          batt::make_case_of_visitor(BATT_FORWARD(case_fns)...));
 }
 
@@ -101,6 +112,7 @@ template <
 StatusOr<R> visit_leaf_page(llfs::PageLoader& page_loader,
                             llfs::PinnedPage& pinned_page_out,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   if (!pinned_page_out || pinned_page_out.page_id() != page_id_slot.page_id) {
@@ -111,6 +123,7 @@ StatusOr<R> visit_leaf_page(llfs::PageLoader& page_loader,
                                                         llfs::PinPageToJob::kDefault,
                                                         llfs::OkIfNotFound{false},
                                                         llfs::LruPriority{kLeafLruPriority},
+                                                        overcommit,
                                                     }));
   }
   return BATT_FORWARD(visitor_fn)(PackedLeafPage::view_of(pinned_page_out));
@@ -123,11 +136,16 @@ template <
     typename R = StatusOr<RemoveStatusOr<std::invoke_result_t<VisitorFn, const PackedLeafPage&>>>>
 StatusOr<R> visit_leaf_page(llfs::PageLoader& page_loader,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   llfs::PinnedPage pinned_page;
 
-  return visit_leaf_page(page_loader, pinned_page, page_id_slot, BATT_FORWARD(visitor_fn));
+  return visit_leaf_page(page_loader,
+                         pinned_page,
+                         page_id_slot,
+                         overcommit,
+                         BATT_FORWARD(visitor_fn));
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -138,6 +156,7 @@ template <
 StatusOr<R> visit_node_page(llfs::PageLoader& page_loader,
                             llfs::PinnedPage& pinned_page_out,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   if (!pinned_page_out || pinned_page_out.page_id() != page_id_slot.page_id) {
@@ -148,6 +167,7 @@ StatusOr<R> visit_node_page(llfs::PageLoader& page_loader,
                                                         llfs::PinPageToJob::kDefault,
                                                         llfs::OkIfNotFound{false},
                                                         llfs::LruPriority{kNodeLruPriority},
+                                                        overcommit,
                                                     }));
   }
   return BATT_FORWARD(visitor_fn)(PackedNodePage::view_of(pinned_page_out));
@@ -160,11 +180,16 @@ template <
     typename R = StatusOr<RemoveStatusOr<std::invoke_result_t<VisitorFn, const PackedNodePage&>>>>
 StatusOr<R> visit_node_page(llfs::PageLoader& page_loader,
                             const llfs::PageIdSlot& page_id_slot,
+                            llfs::PageCacheOvercommit& overcommit,
                             VisitorFn&& visitor_fn)
 {
   llfs::PinnedPage pinned_page;
 
-  return visit_node_page(page_loader, pinned_page, page_id_slot, BATT_FORWARD(visitor_fn));
+  return visit_node_page(page_loader,
+                         pinned_page,
+                         page_id_slot,
+                         overcommit,
+                         BATT_FORWARD(visitor_fn));
 }
 
 }  // namespace turtle_kv


### PR DESCRIPTION
## Other significant changes:

### `TURTLE_KV_PROFILE_QUERIES`/`TURTLE_KV_PROFILE_QUERIES`

Added to `turtle_kv/config.hpp` to control whether metric collection is compiled along critical paths.

### `BatchUpdateMetrics`

Metrics are now collected for batch updates in particular; these are propagated through the call stack via the BatchUpdate struct; this motivates changing a lot of function signatures that previously received PageLoader, to now take a BatchUpdate ref.  This also allowed some cleanup inside the node algorithms code to update pending bytes counts.

### `try_split`/`try_split_direct`

Refacted InMemoryNode splitting to better separate the core "direct" splitting code from the outer retry loop that detects certain exceptional conditions and applies heuristic fixes.

### Trie Index building (`PackedLeafPage`)

Added some new code to handle edge cases (e.g. leaf contains a single key, item count is less than 16, etc.)
