### PR TITLE
Add active pivot overflow bit set to Update Buffer Segment

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -56,10 +56,10 @@ class TurtleKvRecipe(ConanFile):
         }
 
         self.requires("abseil/20250127.0", **VISIBLE, **OVERRIDE)
-        self.requires("batteries/[>=0.61.0 <1]", **VISIBLE, **OVERRIDE)
+        self.requires("batteries/[>=0.65.0 <1]", **VISIBLE, **OVERRIDE)
         self.requires("boost/1.88.0", **VISIBLE, **OVERRIDE)
         self.requires("glog/0.7.1", **VISIBLE)
-        self.requires("llfs/[>=0.43.3 <1]", **VISIBLE)
+        self.requires("llfs/[>=0.43.4 <1]", **VISIBLE)
         self.requires("pcg-cpp/cci.20220409", **VISIBLE)
         self.requires("zlib/1.3.1", **OVERRIDE)
 

--- a/src/turtle_kv/change_log_writer.cpp
+++ b/src/turtle_kv/change_log_writer.cpp
@@ -255,7 +255,7 @@ void ChangeLogWriter::writer_task_main() noexcept
         // appending; in this case, enter our timed polling loop.
         //
         const i64 delay_usec = pick_delay_usec(rng);
-        batt::Task::sleep(boost::posix_time::microseconds(delay_usec));
+        batt::Task::sleep(std::chrono::microseconds(delay_usec));
 
         if (this->halt_requested_.load()) {
           return batt::OkStatus();

--- a/src/turtle_kv/config.hpp
+++ b/src/turtle_kv/config.hpp
@@ -91,6 +91,12 @@ constexpr i64 kNewLeafLruPriority = kLeafLruPriority + kNewPagePriorityBoost;
 
 constexpr u32 kDefaultLeafShardedViewSize = 4096;
 
-constexpr usize kMaxPivots = 64;
+/** \brief The minimum number of pivots allowed in a non-root node.
+ */
+inline constexpr usize kMinPivots = 4;
+
+/** \brief The maximum number of pivots allowed in a packed node.
+ */
+inline constexpr usize kMaxPivots = 64;
 
 }  // namespace turtle_kv

--- a/src/turtle_kv/config.hpp
+++ b/src/turtle_kv/config.hpp
@@ -91,4 +91,6 @@ constexpr i64 kNewLeafLruPriority = kLeafLruPriority + kNewPagePriorityBoost;
 
 constexpr u32 kDefaultLeafShardedViewSize = 4096;
 
+constexpr usize kMaxPivots = 64;
+
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -134,8 +134,13 @@ class ActivePivotsSet128 : public ActivePivotsSetBase<std::array<u64, 2>>
       return;
     }
 
-    this->bit_set_[0] = (this->bit_set_[0] >> count) | (this->bit_set_[1] << (64 - count));
-    this->bit_set_[1] >>= count;
+    if (count < 64) {
+      this->bit_set_[0] = (this->bit_set_[0] >> count) | (this->bit_set_[1] << (64 - count));
+      this->bit_set_[1] >>= count;
+    } else {
+      this->bit_set_[0] = this->bit_set_[1] >> (count - 64);
+      this->bit_set_[1] = 0;
+    }
   }
 };
 

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -33,10 +33,16 @@ concept ActivePivotsSet = requires(T pivots) {
   // last
   { std::declval<const T&>().last() } -> std::convertible_to<i32>;
 
+  // next
+  { std::declval<const T&>().next(std::declval<i32>()) } -> std::convertible_to<i32>;
+
   // printable
   {
     std::declval<std::ostream&>() << std::declval<const T&>().printable()
   } -> std::convertible_to<std::ostream&>;
+
+  // is_inactive
+  { std::declval<const T&>().is_inactive() } -> std::same_as<bool>;
 };
 
 template <typename T>
@@ -44,15 +50,20 @@ concept HasActivePivotsSet = requires(const T& obj) {
   { obj.get_active_pivots() } -> ActivePivotsSet;
 };
 
-class PackedActivePivotsSet64;
-
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
-class ActivePivotsSet128
+/** \brief Base class for active pivot bit set representation. Implements basic bit operations.
+ */
+template <typename Bitset>
+class ActivePivotsSetBase
 {
-  friend class PackedActivePivotsSet64;
-
  public:
+  BATT_ALWAYS_INLINE ActivePivotsSetBase() noexcept : bit_set_{} {}
+
+  BATT_ALWAYS_INLINE explicit ActivePivotsSetBase(const Bitset& bit_set) : bit_set_{bit_set}
+  {
+  }
+
   BATT_ALWAYS_INLINE usize count() const
   {
     return bit_count(this->bit_set_);
@@ -78,69 +89,83 @@ class ActivePivotsSet128
     return last_bit(this->bit_set_);
   }
 
-  auto printable() const
+  BATT_ALWAYS_INLINE i32 next(i32 i) const
+  {
+    return next_bit(this->bit_set_, i);
+  }
+
+  BATT_ALWAYS_INLINE void insert(i32 i, bool v)
+  {
+    this->bit_set_ = insert_bit(this->bit_set_, i, v);
+  }
+
+  BATT_ALWAYS_INLINE bool is_inactive() const
+  {
+    return this->bit_set_ == Bitset{};
+  }
+
+ protected:
+  Bitset bit_set_;
+};
+
+class PackedActivePivotsSet64;
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+/** \brief Representation of a 128-bit bit set of active pivots.
+ */
+class ActivePivotsSet128 : public ActivePivotsSetBase<std::array<u64, 2>>
+{
+  friend class PackedActivePivotsSet64;
+
+ public:
+  BATT_ALWAYS_INLINE auto printable() const
   {
     return [this](std::ostream& out) {
       out << std::bitset<64>{this->bit_set_[1]} << "," << std::bitset<64>{this->bit_set_[1]};
     };
   }
 
- private:
-  std::array<u64, 2> bit_set_ = {0, 0};
+  /** \brief Removes the specified number (`count`) pivots from the bit set.
+ */
+  BATT_ALWAYS_INLINE void pop_front_pivots(i32 count)
+  {
+    if (count < 1) {
+      return;
+    }
+
+    this->bit_set_[0] = (this->bit_set_[0] >> count) | (this->bit_set_[1] << (64 - count));
+    this->bit_set_[1] >>= count;
+  }
 };
 
 static_assert(ActivePivotsSet<ActivePivotsSet128>);
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
-class PackedActivePivotsSet64
+/** \brief A packed representation of a 64-bit bit set of active pivots.
+ */
+class PackedActivePivotsSet64 : public ActivePivotsSetBase<little_u64>
 {
  public:
-  /*implicit*/ PackedActivePivotsSet64(const ActivePivotsSet128& src) noexcept
-      : bit_set_{src.bit_set_[0]}
+  BATT_ALWAYS_INLINE /*implicit*/ PackedActivePivotsSet64(const ActivePivotsSet128& src) noexcept
+      : ActivePivotsSetBase<little_u64>{little_u64{src.bit_set_[0]}}
   {
     BATT_CHECK_EQ(src.bit_set_[1], 0);
   }
 
-  ActivePivotsSet128 unpack() const
+  BATT_ALWAYS_INLINE ActivePivotsSet128 unpack() const
   {
     ActivePivotsSet128 unpacked;
     unpacked.bit_set_[0] = this->bit_set_;
+    unpacked.bit_set_[1] = 0;
     return unpacked;
   }
 
-  BATT_ALWAYS_INLINE usize count() const
-  {
-    return bit_count(this->bit_set_);
-  }
-
-  BATT_ALWAYS_INLINE void set(i32 i, bool v)
-  {
-    this->bit_set_ = set_bit(this->bit_set_, i, v);
-  }
-
-  BATT_ALWAYS_INLINE bool get(i32 i) const
-  {
-    return get_bit(this->bit_set_, i);
-  }
-
-  BATT_ALWAYS_INLINE i32 first() const
-  {
-    return first_bit(this->bit_set_);
-  }
-
-  BATT_ALWAYS_INLINE i32 last() const
-  {
-    return last_bit(this->bit_set_);
-  }
-
-  auto printable() const
+  BATT_ALWAYS_INLINE auto printable() const
   {
     return std::bitset<64>{this->bit_set_.value()};
   }
-
- private:
-  little_u64 bit_set_;
 };
 
 static_assert(ActivePivotsSet<PackedActivePivotsSet64>);

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -17,37 +17,47 @@ namespace turtle_kv {
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
 template <typename T>
-concept ActivePivotsSet = requires(T pivots) {
+concept ConstActivePivotsSet = requires(const T& obj, i32 index, bool value, std::ostream& out) {
   // count
-  { std::declval<const T&>().count() } -> std::convertible_to<usize>;
-
-  // set
-  { pivots.set(std::declval<i32>(), std::declval<bool>()) } -> std::same_as<void>;
+  { obj.count() } -> std::convertible_to<usize>;
 
   // get
-  { std::declval<const T&>().get(std::declval<i32>()) } -> std::same_as<bool>;
+  { obj.get(index) } -> std::convertible_to<bool>;
 
   // first
-  { std::declval<const T&>().first() } -> std::convertible_to<i32>;
+  { obj.first() } -> std::convertible_to<i32>;
 
   // last
-  { std::declval<const T&>().last() } -> std::convertible_to<i32>;
+  { obj.last() } -> std::convertible_to<i32>;
 
   // next
-  { std::declval<const T&>().next(std::declval<i32>()) } -> std::convertible_to<i32>;
+  { obj.next(index) } -> std::convertible_to<i32>;
 
   // printable
-  {
-    std::declval<std::ostream&>() << std::declval<const T&>().printable()
-  } -> std::convertible_to<std::ostream&>;
+  { out << obj.printable() } -> std::convertible_to<std::ostream&>;
 
-  // is_inactive
-  { std::declval<const T&>().is_inactive() } -> std::same_as<bool>;
+  // is_empty
+  { obj.is_empty() } -> std::convertible_to<bool>;
 };
 
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
 template <typename T>
-concept HasActivePivotsSet = requires(const T& obj) {
-  { obj.get_active_pivots() } -> ActivePivotsSet;
+concept MutableActivePivotsSet = requires(T& obj, i32 index, bool value) {
+  // set
+  { obj.set(index, value) };
+};
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+template <typename T>
+concept ActivePivotsSet = ConstActivePivotsSet<T> && MutableActivePivotsSet<T>;
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+template <typename T>
+concept HasConstActivePivotsSet = requires(const T& obj) {
+  { obj.get_active_pivots() } -> ConstActivePivotsSet;
 };
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
@@ -58,7 +68,9 @@ template <typename Bitset>
 class ActivePivotsSetBase
 {
  public:
-  BATT_ALWAYS_INLINE ActivePivotsSetBase() noexcept : bit_set_{} {}
+  BATT_ALWAYS_INLINE ActivePivotsSetBase() noexcept : bit_set_{}
+  {
+  }
 
   BATT_ALWAYS_INLINE explicit ActivePivotsSetBase(const Bitset& bit_set) : bit_set_{bit_set}
   {
@@ -99,7 +111,7 @@ class ActivePivotsSetBase
     this->bit_set_ = insert_bit(this->bit_set_, i, v);
   }
 
-  BATT_ALWAYS_INLINE bool is_inactive() const
+  BATT_ALWAYS_INLINE bool is_empty() const
   {
     return this->bit_set_ == Bitset{};
   }
@@ -127,7 +139,7 @@ class ActivePivotsSet128 : public ActivePivotsSetBase<std::array<u64, 2>>
   }
 
   /** \brief Removes the specified number (`count`) pivots from the bit set.
- */
+   */
   BATT_ALWAYS_INLINE void pop_front_pivots(i32 count)
   {
     if (count < 1) {

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -131,6 +131,25 @@ class ActivePivotsSet128 : public ActivePivotsSetBase<std::array<u64, 2>>
   friend class PackedActivePivotsSet64;
 
  public:
+  using Super = ActivePivotsSetBase<std::array<u64, 2>>;
+  using Self = ActivePivotsSet128;
+
+  BATT_ALWAYS_INLINE ActivePivotsSet128() noexcept : Super{}
+  {
+    // Make sure the bit set starts out empty.
+    //
+    this->clear();
+  }
+
+  /** \brief Removes all pivots from the set.
+   */
+  BATT_ALWAYS_INLINE void clear()
+  {
+    this->bit_set_.fill(0);
+  }
+
+  /** \brief Returns a printable representation of this object.
+   */
   BATT_ALWAYS_INLINE auto printable() const
   {
     return [this](std::ostream& out) {

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -1,0 +1,148 @@
+#pragma once
+#define TURTLE_KV_TREE_ACTIVE_PIVOTS_SET_HPP
+
+#include <turtle_kv/import/bit_ops.hpp>
+#include <turtle_kv/import/int_types.hpp>
+
+#include <batteries/stream_util.hpp>
+#include <batteries/utility.hpp>
+
+#include <array>
+#include <bitset>
+#include <ostream>
+#include <type_traits>
+
+namespace turtle_kv {
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+template <typename T>
+concept ActivePivotsSet = requires(T pivots) {
+  // count
+  { std::declval<const T&>().count() } -> std::convertible_to<usize>;
+
+  // set
+  { pivots.set(std::declval<i32>(), std::declval<bool>()) } -> std::same_as<void>;
+
+  // get
+  { std::declval<const T&>().get(std::declval<i32>()) } -> std::same_as<bool>;
+
+  // first
+  { std::declval<const T&>().first() } -> std::convertible_to<i32>;
+
+  // last
+  { std::declval<const T&>().last() } -> std::convertible_to<i32>;
+
+  // printable
+  {
+    std::declval<std::ostream&>() << std::declval<const T&>().printable()
+  } -> std::convertible_to<std::ostream&>;
+};
+
+template <typename T>
+concept HasActivePivotsSet = requires(const T& obj) {
+  { obj.get_active_pivots() } -> ActivePivotsSet;
+};
+
+class PackedActivePivotsSet64;
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+class ActivePivotsSet128
+{
+  friend class PackedActivePivotsSet64;
+
+ public:
+  BATT_ALWAYS_INLINE usize count() const
+  {
+    return bit_count(this->bit_set_);
+  }
+
+  BATT_ALWAYS_INLINE void set(i32 i, bool v)
+  {
+    this->bit_set_ = set_bit(this->bit_set_, i, v);
+  }
+
+  BATT_ALWAYS_INLINE bool get(i32 i) const
+  {
+    return get_bit(this->bit_set_, i);
+  }
+
+  BATT_ALWAYS_INLINE i32 first() const
+  {
+    return first_bit(this->bit_set_);
+  }
+
+  BATT_ALWAYS_INLINE i32 last() const
+  {
+    return last_bit(this->bit_set_);
+  }
+
+  auto printable() const
+  {
+    return [this](std::ostream& out) {
+      out << std::bitset<64>{this->bit_set_[1]} << "," << std::bitset<64>{this->bit_set_[1]};
+    };
+  }
+
+ private:
+  std::array<u64, 2> bit_set_ = {0, 0};
+};
+
+static_assert(ActivePivotsSet<ActivePivotsSet128>);
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+class PackedActivePivotsSet64
+{
+ public:
+  /*implicit*/ PackedActivePivotsSet64(const ActivePivotsSet128& src) noexcept
+      : bit_set_{src.bit_set_[0]}
+  {
+    BATT_CHECK_EQ(src.bit_set_[1], 0);
+  }
+
+  ActivePivotsSet128 unpack() const
+  {
+    ActivePivotsSet128 unpacked;
+    unpacked.bit_set_[0] = this->bit_set_;
+    return unpacked;
+  }
+
+  BATT_ALWAYS_INLINE usize count() const
+  {
+    return bit_count(this->bit_set_);
+  }
+
+  BATT_ALWAYS_INLINE void set(i32 i, bool v)
+  {
+    this->bit_set_ = set_bit(this->bit_set_, i, v);
+  }
+
+  BATT_ALWAYS_INLINE bool get(i32 i) const
+  {
+    return get_bit(this->bit_set_, i);
+  }
+
+  BATT_ALWAYS_INLINE i32 first() const
+  {
+    return first_bit(this->bit_set_);
+  }
+
+  BATT_ALWAYS_INLINE i32 last() const
+  {
+    return last_bit(this->bit_set_);
+  }
+
+  auto printable() const
+  {
+    return std::bitset<64>{this->bit_set_.value()};
+  }
+
+ private:
+  little_u64 bit_set_;
+};
+
+static_assert(ActivePivotsSet<PackedActivePivotsSet64>);
+
+}  // namespace turtle_kv

--- a/src/turtle_kv/tree/active_pivots_set.hpp
+++ b/src/turtle_kv/tree/active_pivots_set.hpp
@@ -205,5 +205,6 @@ class PackedActivePivotsSet64 : public ActivePivotsSetBase<little_u64>
 };
 
 static_assert(ActivePivotsSet<PackedActivePivotsSet64>);
+static_assert(sizeof(PackedActivePivotsSet64) == 8);
 
 }  // namespace turtle_kv

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -91,21 +91,22 @@ inline i32 get_last_active_pivot(const CInterval<usize>& pivot_range)
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 
 template <typename T>
-using EnableIfHasActivePivotsBitset =
-    std::enable_if_t<std::is_convertible_v<decltype(std::declval<T&&>().get_active_pivots()), u64>>;
+using EnableIfHasActivePivotsBitset = std::enable_if_t<
+    std::is_convertible_v<decltype(std::declval<T&&>().get_active_pivots_with_overflow()),
+                          std::array<u64, 2>>>;
 
 //----- --- -- -  -  -   -
 
 template <typename T, typename = EnableIfHasActivePivotsBitset<T>>
 inline i32 get_first_active_pivot(T&& segment)
 {
-  return first_bit(segment.get_active_pivots());
+  return first_bit(segment.get_active_pivots_with_overflow());
 }
 
 template <typename T, typename = EnableIfHasActivePivotsBitset<T>>
 inline i32 get_last_active_pivot(T&& segment)
 {
-  return last_bit(segment.get_active_pivots());
+  return last_bit(segment.get_active_pivots_with_overflow());
 }
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -181,8 +181,7 @@ struct SegmentedLevelAlgorithms {
 
       // Skip this segment if the pivot is not active.
       //
-      const u64 active_pivots = segment.get_active_pivots();
-      if (!get_bit(active_pivots, pivot_i)) {
+      if (!segment.is_pivot_active(pivot_i)) {
         ++segment_i;
         continue;
       }
@@ -208,7 +207,7 @@ struct SegmentedLevelAlgorithms {
 
       // Drop the segment if it has become inactive due to the flush.
       //
-      if (segment.get_active_pivots() == 0) {
+      if (segment.is_inactive()) {
         this->level_.drop_segment(segment_i);
       } else {
         ++segment_i;
@@ -236,7 +235,7 @@ struct SegmentedLevelAlgorithms {
             << batt::c_str_literal(old_pivot_key_range.upper_bound)
             << "), key=" << batt::c_str_literal(split_key) << ")";
 
-    BATT_CHECK_LT(this->node_.pivot_count(), 64);
+    BATT_CHECK_LT(this->node_.pivot_count(), 67);
 
     const KeyView pivot_key = old_pivot_key_range.lower_bound;
     const usize segment_count = this->level_.segment_count();

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -235,7 +235,7 @@ struct SegmentedLevelAlgorithms {
             << batt::c_str_literal(old_pivot_key_range.upper_bound)
             << "), key=" << batt::c_str_literal(split_key) << ")";
 
-    BATT_CHECK_LT(this->node_.pivot_count(), 67);
+    BATT_CHECK_LT(this->node_.pivot_count(), InMemoryNode::kMaxTempPivots);
 
     const KeyView pivot_key = old_pivot_key_range.lower_bound;
     const usize segment_count = this->level_.segment_count();

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -242,7 +242,7 @@ struct SegmentedLevelAlgorithms {
 
       // If we can split the pivot without loading the leaf, great!
       //
-      if (in_segment(segment).split_pivot(pivot_i, None, this->level_)) {
+      if (in_segment(segment).split_pivot(pivot_i, /*split_indices=*/None, this->level_)) {
         continue;
       }
 
@@ -255,17 +255,29 @@ struct SegmentedLevelAlgorithms {
 
       const PackedLeafPage& leaf_page = PackedLeafPage::view_of(segment_pinned_leaf);
 
-      const usize pivot_offset_in_leaf =
-          std::distance(leaf_page.items_begin(), leaf_page.lower_bound(pivot_key));
+      const auto first_item_in_leaf = leaf_page.items_begin();
+
+      const usize pivot_begin_in_leaf =
+          std::distance(first_item_in_leaf, leaf_page.lower_bound(pivot_key));
 
       const usize split_offset_in_leaf =
-          std::distance(leaf_page.items_begin(), leaf_page.lower_bound(split_key));
+          std::distance(first_item_in_leaf, leaf_page.lower_bound(split_key));
 
-      VLOG(1) << " --" << BATT_INSPECT(split_offset_in_leaf) << BATT_INSPECT(pivot_offset_in_leaf);
+      const usize pivot_end_in_leaf =
+          std::distance(first_item_in_leaf, leaf_page.lower_bound(old_pivot_key_range.upper_bound));
 
-      BATT_CHECK_LE(pivot_offset_in_leaf, split_offset_in_leaf);
+      VLOG(1) << " --" << BATT_INSPECT(split_offset_in_leaf) << BATT_INSPECT(pivot_begin_in_leaf);
 
-      BATT_CHECK(in_segment(segment).split_pivot(pivot_i, split_offset_in_leaf, this->level_));
+      BATT_CHECK_LE(pivot_begin_in_leaf, split_offset_in_leaf);
+      BATT_CHECK_LE(split_offset_in_leaf, pivot_end_in_leaf);
+
+      BATT_CHECK(in_segment(segment).split_pivot(pivot_i,
+                                                 SegmentPivotSplitIndices{
+                                                     pivot_begin_in_leaf,
+                                                     split_offset_in_leaf,
+                                                     pivot_end_in_leaf,
+                                                 },
+                                                 this->level_));
     }
 
     return OkStatus();

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -92,21 +92,20 @@ inline i32 get_last_active_pivot(const CInterval<usize>& pivot_range)
 
 template <typename T>
 using EnableIfHasActivePivotsBitset = std::enable_if_t<
-    std::is_convertible_v<decltype(std::declval<T&&>().get_active_pivots_with_overflow()),
-                          std::array<u64, 2>>>;
+    ActivePivotsSet<decltype(std::declval<std::decay_t<T>>().get_active_pivots())>>;
 
 //----- --- -- -  -  -   -
 
-template <typename T, typename = EnableIfHasActivePivotsBitset<T>>
-inline i32 get_first_active_pivot(T&& segment)
+template <HasActivePivotsSet T>
+inline i32 get_first_active_pivot(const T& segment)
 {
-  return first_bit(segment.get_active_pivots_with_overflow());
+  return segment.get_active_pivots().first();
 }
 
-template <typename T, typename = EnableIfHasActivePivotsBitset<T>>
-inline i32 get_last_active_pivot(T&& segment)
+template <HasActivePivotsSet T>
+inline i32 get_last_active_pivot(const T& segment)
 {
-  return last_bit(segment.get_active_pivots_with_overflow());
+  return segment.get_active_pivots().last();
 }
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -88,12 +88,6 @@ inline i32 get_last_active_pivot(const CInterval<usize>& pivot_range)
   return pivot_range.upper_bound;
 }
 
-//==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
-
-template <typename T>
-using EnableIfHasActivePivotsBitset = std::enable_if_t<
-    ActivePivotsSet<decltype(std::declval<std::decay_t<T>>().get_active_pivots())>>;
-
 //----- --- -- -  -  -   -
 
 template <HasActivePivotsSet T>

--- a/src/turtle_kv/tree/algo/segmented_levels.hpp
+++ b/src/turtle_kv/tree/algo/segmented_levels.hpp
@@ -90,13 +90,13 @@ inline i32 get_last_active_pivot(const CInterval<usize>& pivot_range)
 
 //----- --- -- -  -  -   -
 
-template <HasActivePivotsSet T>
+template <HasConstActivePivotsSet T>
 inline i32 get_first_active_pivot(const T& segment)
 {
   return segment.get_active_pivots().first();
 }
 
-template <HasActivePivotsSet T>
+template <HasConstActivePivotsSet T>
 inline i32 get_last_active_pivot(const T& segment)
 {
   return segment.get_active_pivots().last();

--- a/src/turtle_kv/tree/algo/segments.hpp
+++ b/src/turtle_kv/tree/algo/segments.hpp
@@ -11,12 +11,72 @@
 
 #include <batteries/assert.hpp>
 #include <batteries/bool_status.hpp>
+#include <batteries/checked_cast.hpp>
 #include <batteries/seq/loop_control.hpp>
 
 #include <algorithm>
 
 namespace turtle_kv {
 
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
+/** \brief The set of indices involved in a pivot split; each index is a 0-based item index within
+ * the leaf page.
+ */
+struct SegmentPivotSplitIndices {
+  /** \brief The lower bound (inclusive) of the lower-half of the split.  This is also the lower
+   * bound of the pre-split region.
+   */
+  u32 lower_bound;
+
+  /** \brief The index of the first item belonging to the right-hand-side after the split.
+   * This is the upper bound (non-inclusive) of the new lower-half, and the lower bound
+   * (inclusive) of the new upper-half.
+   */
+  u32 split_point;
+
+  /** \brief The uppwer bound (non-inclusive) of the upper-half of the split.  This is also the
+   * upper bound of the pre-split region.
+   */
+  u32 upper_bound;
+
+  //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  SegmentPivotSplitIndices() = delete;
+
+  explicit SegmentPivotSplitIndices(u32 lower, u32 middle, u32 upper) noexcept
+      : lower_bound{lower}
+      , split_point{middle}
+      , upper_bound{upper}
+  {
+  }
+
+  explicit SegmentPivotSplitIndices(usize lower, usize middle, usize upper) noexcept
+      : SegmentPivotSplitIndices{
+            BATT_CHECKED_CAST(u32, lower),
+            BATT_CHECKED_CAST(u32, middle),
+            BATT_CHECKED_CAST(u32, upper),
+        }
+  {
+  }
+
+  /** \brief Returns the lower half index range for the split.
+   */
+  Interval<u32> lower_range() const
+  {
+    return {this->lower_bound, this->split_point};
+  }
+
+  /** \brief Returns the upper half index range for the split.
+   */
+  Interval<u32> upper_range() const
+  {
+    return {this->split_point, this->upper_bound};
+  }
+};
+
+//=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
+//
 template <typename SegmentT>
 struct SegmentAlgorithms {
   //+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -38,7 +98,7 @@ struct SegmentAlgorithms {
    */
   template <typename LevelT>
   [[nodiscard]] bool split_pivot(i32 pivot_i,
-                                 Optional<usize> split_offset_in_leaf,
+                                 Optional<SegmentPivotSplitIndices> split_indices,
                                  const LevelT& level) const
   {
     using batt::BoolStatus;
@@ -48,7 +108,7 @@ struct SegmentAlgorithms {
       this->segment_.check_invariants(__FILE__, __LINE__);
     });
 
-    BATT_CHECK_LT(pivot_i, InMemoryNode::kMaxTempPivots - 1);
+    BATT_CHECK_LT(pivot_i, (i32)InMemoryNode::kMaxTempPivots - 1);
 
     // Simplest case: pivot not active for this segment.
     //
@@ -57,52 +117,26 @@ struct SegmentAlgorithms {
       return true;
     }
 
-    const BoolStatus old_pivot_becomes_inactive = [&] {
-      if (!split_offset_in_leaf) {
-        return BoolStatus::kUnknown;
-      }
-
-      if (*split_offset_in_leaf == 0) {
-        return BoolStatus::kTrue;
-      }
-
-      return batt::bool_status_from(
-          this->segment_.is_index_filtered(level, *split_offset_in_leaf - 1));
-    }();
-
-    const BoolStatus new_pivot_has_flushed_items = [&] {
-      if (old_pivot_becomes_inactive == BoolStatus::kUnknown) {
-        return BoolStatus::kUnknown;
-      }
-
-      return batt::bool_status_from(old_pivot_becomes_inactive == BoolStatus::kTrue &&
-                                    this->segment_.is_index_filtered(level, *split_offset_in_leaf));
-    }();
-
-    // Next simplest: pivot active, but flush count is zero for pivot.
+    // If the pivot we are splitting is currently active, then we need to know the split_indices
+    // before we can accurately compute whether the lower/upper ranges of the split are active.
     //
-    if (old_pivot_becomes_inactive == BoolStatus::kFalse) {
-      BATT_CHECK_EQ(new_pivot_has_flushed_items, BoolStatus::kFalse);
-      this->segment_.insert_pivot(pivot_i + 1, true);
-      return true;
-    }
-
-    // At this point we can only proceed if we know the item count of the split position relative to
-    // the pivot key range start.
-    //
-    if (old_pivot_becomes_inactive == BoolStatus::kUnknown ||
-        new_pivot_has_flushed_items == BoolStatus::kUnknown) {
+    if (!split_indices) {
       return false;
     }
 
-    BATT_CHECK_EQ(old_pivot_becomes_inactive, BoolStatus::kTrue);
-    BATT_CHECK(split_offset_in_leaf);
-
-    // If the split is not after the last flushed item, then the lower pivot (in the split) is now
-    // inactive and the upper one is active, possibly with some flushed items.
+    // Ask the segment filter whether the lower/upper ranges of the split have live items.
     //
-    this->segment_.set_pivot_active(pivot_i, false);
-    this->segment_.insert_pivot(pivot_i + 1, true);
+    const Interval<u32> lower_live_range =
+        this->segment_.get_live_item_range(level, split_indices->lower_range());
+
+    const Interval<u32> upper_live_range =
+        this->segment_.get_live_item_range(level, split_indices->upper_range());
+
+    const bool lower_pivot_active = !lower_live_range.empty();
+    const bool upper_pivot_active = !upper_live_range.empty();
+
+    this->segment_.set_pivot_active(pivot_i, lower_pivot_active);
+    this->segment_.insert_pivot(pivot_i + 1, upper_pivot_active);
 
     return true;
   }

--- a/src/turtle_kv/tree/algo/segments.hpp
+++ b/src/turtle_kv/tree/algo/segments.hpp
@@ -117,16 +117,13 @@ struct SegmentAlgorithms {
     // they were when this function was entered, regardless of what `fn` may do to change the state
     // of the segment.
     //
-    const std::array<u64, 2> observed_active_pivots =
-        this->segment_.get_active_pivots_with_overflow();
-
-    const i32 first_active_pivot = first_bit(observed_active_pivots);
+    const auto observed_active_pivots = this->segment_.get_active_pivots();
 
     const i32 first_pivot_i = std::max<i32>(pivot_range.lower_bound,  //
-                                            first_active_pivot);
+                                            observed_active_pivots.first());
 
     for (i32 pivot_i = first_pivot_i; pivot_i < pivot_range.upper_bound;
-         pivot_i = next_bit(observed_active_pivots, pivot_i)) {
+         pivot_i = observed_active_pivots.next(pivot_i)) {
       BATT_INVOKE_LOOP_FN((fn, this->segment_, pivot_i));
     }
   }

--- a/src/turtle_kv/tree/algo/segments.hpp
+++ b/src/turtle_kv/tree/algo/segments.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <turtle_kv/tree/key_query.hpp>
+#include <turtle_kv/tree/in_memory_node.hpp>
 #include <turtle_kv/tree/packed_leaf_page.hpp>
 #include <turtle_kv/tree/tree_options.hpp>
 
@@ -47,7 +48,7 @@ struct SegmentAlgorithms {
       this->segment_.check_invariants(__FILE__, __LINE__);
     });
 
-    BATT_CHECK_LT(pivot_i, 67);
+    BATT_CHECK_LT(pivot_i, InMemoryNode::kMaxTempPivots - 1);
 
     // Simplest case: pivot not active for this segment.
     //

--- a/src/turtle_kv/tree/algo/segments.hpp
+++ b/src/turtle_kv/tree/algo/segments.hpp
@@ -47,7 +47,7 @@ struct SegmentAlgorithms {
       this->segment_.check_invariants(__FILE__, __LINE__);
     });
 
-    BATT_CHECK_LT(pivot_i, 63);
+    BATT_CHECK_LT(pivot_i, 67);
 
     // Simplest case: pivot not active for this segment.
     //
@@ -116,14 +116,32 @@ struct SegmentAlgorithms {
     // they were when this function was entered, regardless of what `fn` may do to change the state
     // of the segment.
     //
-    const u64 observed_active_pivots = this->segment_.get_active_pivots();
+    const std::pair<u64, u64> observed_active_pivots =
+        this->segment_.get_active_pivots_with_overflow();
+
+    const u64 first_active_bit = first_bit(observed_active_pivots.first);
+    const u64 first_active_overflow_bit = first_bit(observed_active_pivots.second);
+    const u64 first_active_pivot =
+        (first_active_bit != 64) ? first_active_bit : (first_active_overflow_bit + 64);
 
     const i32 first_pivot_i = std::max<i32>(pivot_range.lower_bound,  //
-                                            first_bit(observed_active_pivots));
+                                            first_active_pivot);
 
-    for (i32 pivot_i = first_pivot_i; pivot_i < pivot_range.upper_bound;
-         pivot_i = next_bit(observed_active_pivots, pivot_i)) {
+    for (i32 pivot_i = first_pivot_i; pivot_i < pivot_range.upper_bound;) {
       BATT_INVOKE_LOOP_FN((fn, this->segment_, pivot_i));
+
+      if (pivot_i < 64) {
+        pivot_i = next_bit(observed_active_pivots.first, pivot_i);
+        if (pivot_i == 64) {
+          pivot_i = first_bit(observed_active_pivots.second) + 64;
+        }
+      } else {
+        const i32 overflow_i = pivot_i - 64;
+        if (overflow_i >= 64) {
+          break;
+        }
+        pivot_i = next_bit(observed_active_pivots.second, overflow_i) + 64;
+      }
     }
   }
 

--- a/src/turtle_kv/tree/algo/segments.hpp
+++ b/src/turtle_kv/tree/algo/segments.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <turtle_kv/tree/key_query.hpp>
 #include <turtle_kv/tree/in_memory_node.hpp>
+#include <turtle_kv/tree/key_query.hpp>
 #include <turtle_kv/tree/packed_leaf_page.hpp>
 #include <turtle_kv/tree/tree_options.hpp>
 
@@ -117,32 +117,17 @@ struct SegmentAlgorithms {
     // they were when this function was entered, regardless of what `fn` may do to change the state
     // of the segment.
     //
-    const std::pair<u64, u64> observed_active_pivots =
+    const std::array<u64, 2> observed_active_pivots =
         this->segment_.get_active_pivots_with_overflow();
 
-    const u64 first_active_bit = first_bit(observed_active_pivots.first);
-    const u64 first_active_overflow_bit = first_bit(observed_active_pivots.second);
-    const u64 first_active_pivot =
-        (first_active_bit != 64) ? first_active_bit : (first_active_overflow_bit + 64);
+    const i32 first_active_pivot = first_bit(observed_active_pivots);
 
     const i32 first_pivot_i = std::max<i32>(pivot_range.lower_bound,  //
                                             first_active_pivot);
 
-    for (i32 pivot_i = first_pivot_i; pivot_i < pivot_range.upper_bound;) {
+    for (i32 pivot_i = first_pivot_i; pivot_i < pivot_range.upper_bound;
+         pivot_i = next_bit(observed_active_pivots, pivot_i)) {
       BATT_INVOKE_LOOP_FN((fn, this->segment_, pivot_i));
-
-      if (pivot_i < 64) {
-        pivot_i = next_bit(observed_active_pivots.first, pivot_i);
-        if (pivot_i == 64) {
-          pivot_i = first_bit(observed_active_pivots.second) + 64;
-        }
-      } else {
-        const i32 overflow_i = pivot_i - 64;
-        if (overflow_i >= 64) {
-          break;
-        }
-        pivot_i = next_bit(observed_active_pivots.second, overflow_i) + 64;
-      }
     }
   }
 

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1721,17 +1721,10 @@ void InMemoryNode::UpdateBuffer::Segment::insert_pivot(i32 pivot_i, bool is_acti
     this->check_invariants(__FILE__, __LINE__);
   });
 
-  if (pivot_i < 64) {
-    // Insert the highest bit from active_pivots to the overflow bit set.
-    //
-    this->active_pivots_overflow =
-        (this->active_pivots_overflow << 1) | ((this->active_pivots >> 63) & u64{1});
-
-    this->active_pivots = insert_bit(this->active_pivots, pivot_i, is_active);
-  } else {
-    const i32 overflow_i = pivot_i - 64;
-    this->active_pivots_overflow = insert_bit(this->active_pivots_overflow, overflow_i, is_active);
-  }
+  std::array<u64, 2> active_pivots_out =
+      insert_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i, is_active);
+  this->active_pivots = active_pivots_out[0];
+  this->active_pivots_overflow = active_pivots_out[1];
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -980,7 +980,7 @@ SubtreeViability InMemoryNode::get_viability() const
   NeedsMerge needs_merge;
 
   needs_merge.single_pivot = (this->pivot_count() == 1);
-  needs_merge.too_few_pivots = (this->pivot_count() < kMinPivotCount);
+  needs_merge.too_few_pivots = (this->pivot_count() < kMinPivots);
 
   if (needs_merge) {
     return needs_merge;
@@ -1259,7 +1259,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the lower half is too large, then move the split point down and retry if possible.
     //
-    if (split_pivot_i > kMinPivotCount && batt::is_case<NeedsSplit>(lower_viability) &&
+    if (split_pivot_i > kMinPivots && batt::is_case<NeedsSplit>(lower_viability) &&
         !batt::is_case<NeedsSplit>(upper_viability)) {
       --split_pivot_i;
       continue;
@@ -1267,7 +1267,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the upper half is too large, then move the split point up and retry if possible.
     //
-    if (split_pivot_i + kMinPivotCount < orig_pivot_count &&
+    if (split_pivot_i + kMinPivots < orig_pivot_count &&
         batt::is_case<NeedsSplit>(upper_viability) && !batt::is_case<NeedsSplit>(lower_viability)) {
       ++split_pivot_i;
       continue;

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1553,7 +1553,7 @@ StatusOr<SegmentedLevel> MergedLevel::finish_serialize(const InMemoryNode& node,
                           context.get_build_page_result(this->segment_future_ids_[segment_i]));
 
     segment.page_id_slot.page_id = pinned_leaf_page.page_id();
-    segment.active_pivots = 0;
+    segment.active_pivots = {};
 
     const PackedLeafPage& leaf_page = PackedLeafPage::view_of(pinned_leaf_page);
 
@@ -1702,43 +1702,25 @@ void InMemoryNode::UpdateBuffer::Segment::insert_pivot(i32 pivot_i, bool is_acti
     this->check_invariants(__FILE__, __LINE__);
   });
 
-  std::array<u64, 2> active_pivots_out =
-      insert_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
-                 pivot_i,
-                 is_active);
-  this->active_pivots = active_pivots_out[0];
-  this->active_pivots_overflow = active_pivots_out[1];
+  this->active_pivots.insert(pivot_i, is_active);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 void InMemoryNode::UpdateBuffer::Segment::pop_front_pivots(i32 count)
 {
-  if (count < 1) {
-    return;
-  }
-
   BATT_CHECK_LT(count, 64);
-
-  // Before we modify the bit sets, make sure we aren't losing any active pivots.
-  //
-  const u64 mask = (u64{1} << count) - 1;
-
-  BATT_CHECK_EQ(bit_count(mask), count);
-  BATT_CHECK_EQ((this->active_pivots & mask), u64{0});
 
   // Shift the active pivot sets down by count.
   //
-  this->active_pivots =
-      (this->active_pivots >> count) | (this->active_pivots_overflow << (64 - count));
-  this->active_pivots_overflow = (this->active_pivots_overflow >> count);
+  this->active_pivots.pop_front_pivots(count);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 bool InMemoryNode::UpdateBuffer::Segment::is_inactive() const
 {
-  const bool inactive = (this->active_pivots == 0 && this->active_pivots_overflow == 0);
+  const bool inactive = this->active_pivots.is_inactive();
   if (inactive) {
     Slice<const Interval<u32>> filter_dropped_ranges = this->filter.dropped();
     BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);
@@ -1800,14 +1782,14 @@ SmallFn<void(std::ostream&)> InMemoryNode::UpdateBuffer::SegmentedLevel::dump() 
 SmallFn<void(std::ostream&)> InMemoryNode::UpdateBuffer::Segment::dump(bool multi_line) const
 {
   return [this, multi_line](std::ostream& out) {
-    auto active = std::bitset<64>{this->active_pivots};
     if (multi_line) {
       out << "Segment:" << std::endl
-          << "   active=" << active << std::endl
+          << "   active=" << this->active_pivots.printable() << std::endl
           << "   filter=" << this->filter.dump() << std::endl
           << std::endl;
     } else {
-      out << "Segment{.active=" << active << ", .filter=" << this->filter.dump() << ",}";
+      out << "Segment{.active=" << this->active_pivots.printable()
+          << ", .filter=" << this->filter.dump() << ",}";
     }
   };
 }

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1553,7 +1553,7 @@ StatusOr<SegmentedLevel> MergedLevel::finish_serialize(const InMemoryNode& node,
                           context.get_build_page_result(this->segment_future_ids_[segment_i]));
 
     segment.page_id_slot.page_id = pinned_leaf_page.page_id();
-    segment.active_pivots = {};
+    segment.active_pivots.clear();
 
     const PackedLeafPage& leaf_page = PackedLeafPage::view_of(pinned_leaf_page);
 

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1118,27 +1118,8 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
   BATT_CHECK_EQ(orig_pivot_count + 1, orig_pivot_keys.size());
 
-  u64 tried_already = 0;
-  u64 tried_already_overflow = 0;
+  std::array<u64, 2> tried_already = {0, 0};
   usize split_pivot_i = (orig_pivot_count + 1) / 2;
-
-  const auto get_tried_bit = [&tried_already, &tried_already_overflow](usize i) -> bool {
-    if (i < 64) {
-      return get_bit(tried_already, i);
-    } else {
-      const i32 overflow_i = i - 64;
-      return get_bit(tried_already_overflow, overflow_i);
-    }
-  };
-
-  auto set_tried_bit = [&tried_already, &tried_already_overflow](usize i) {
-    if (i < 64) {
-      tried_already = set_bit(tried_already, i, true);
-    } else {
-      const i32 overflow_i = i - 64;
-      tried_already_overflow = set_bit(tried_already_overflow, overflow_i, true);
-    }
-  };
 
   auto* node_lower_half = this;
   auto node_upper_half = std::make_unique<InMemoryNode>(batt::make_copy(this->pinned_node_page_),
@@ -1152,10 +1133,10 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
   for (;;) {
     // If we ever try the same split point a second time, fail.
     //
-    if (get_tried_bit(split_pivot_i)) {
+    if (get_bit(tried_already, split_pivot_i)) {
       return {batt::StatusCode::kInternal};
     }
-    set_tried_bit(split_pivot_i);
+    tried_already = set_bit(tried_already, split_pivot_i, true);
 
     //+++++++++++-+-+--+----- --- -- -  -  -   -
 

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1722,7 +1722,9 @@ void InMemoryNode::UpdateBuffer::Segment::insert_pivot(i32 pivot_i, bool is_acti
   });
 
   std::array<u64, 2> active_pivots_out =
-      insert_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i, is_active);
+      insert_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
+                 pivot_i,
+                 is_active);
   this->active_pivots = active_pivots_out[0];
   this->active_pivots_overflow = active_pivots_out[1];
 }

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -3,6 +3,7 @@
 
 #include <turtle_kv/tree/algo/nodes.hpp>
 #include <turtle_kv/tree/algo/segmented_levels.hpp>
+#include <turtle_kv/tree/algo/segments.hpp>
 #include <turtle_kv/tree/filter_builder.hpp>
 #include <turtle_kv/tree/leaf_page_view.hpp>
 #include <turtle_kv/tree/node_page_view.hpp>
@@ -1284,7 +1285,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the upper half is too large, then move the split point up and retry if possible.
     //
-    if (split_pivot_i + 4 < 68 && batt::is_case<NeedsSplit>(upper_viability) &&
+    if (split_pivot_i + 4 < orig_pivot_count && batt::is_case<NeedsSplit>(upper_viability) &&
         !batt::is_case<NeedsSplit>(lower_viability)) {
       ++split_pivot_i;
       continue;
@@ -1646,7 +1647,7 @@ void InMemoryNode::UpdateBuffer::SegmentedLevel::drop_after_pivot(i32 pivot_i,
                                                                   llfs::PageLoader& page_loader,
                                                                   const TreeOptions& tree_options)
 {
-  this->drop_pivot_range((Interval<i32>{pivot_i, 68}),
+  this->drop_pivot_range((Interval<i32>{pivot_i, InMemoryNode::kMaxTempPivots}),
                          (Interval<KeyView>{pivot_key, global_max_key()}),
                          page_loader,
                          tree_options);

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -777,7 +777,7 @@ Status InMemoryNode::set_pivot_completely_flushed(usize pivot_i,
 
             segment.set_pivot_active(pivot_i, false);
 
-            if (segment.get_active_pivots() == 0) {
+            if (segment.is_inactive()) {
               segmented_level.drop_segment(segment_i);
             } else {
               ++segment_i;
@@ -1118,7 +1118,26 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
   BATT_CHECK_EQ(orig_pivot_count + 1, orig_pivot_keys.size());
 
   u64 tried_already = 0;
+  u64 tried_already_overflow = 0;
   usize split_pivot_i = (orig_pivot_count + 1) / 2;
+
+  const auto get_tried_bit = [&tried_already, &tried_already_overflow](usize i) -> bool {
+    if (i < 64) {
+      return get_bit(tried_already, i);
+    } else {
+      const i32 overflow_i = i - 64;
+      return get_bit(tried_already_overflow, overflow_i);
+    }
+  };
+
+  auto set_tried_bit = [&tried_already, &tried_already_overflow](usize i) {
+    if (i < 64) {
+      tried_already = set_bit(tried_already, i, true);
+    } else {
+      const i32 overflow_i = i - 64;
+      tried_already_overflow = set_bit(tried_already_overflow, overflow_i, true);
+    }
+  };
 
   auto* node_lower_half = this;
   auto node_upper_half = std::make_unique<InMemoryNode>(batt::make_copy(this->pinned_node_page_),
@@ -1132,10 +1151,10 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
   for (;;) {
     // If we ever try the same split point a second time, fail.
     //
-    if (get_bit(tried_already, split_pivot_i)) {
+    if (get_tried_bit(split_pivot_i)) {
       return {batt::StatusCode::kInternal};
     }
-    tried_already = set_bit(tried_already, split_pivot_i, true);
+    set_tried_bit(split_pivot_i);
 
     //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -1265,7 +1284,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the upper half is too large, then move the split point up and retry if possible.
     //
-    if (split_pivot_i + 4 < 64 && batt::is_case<NeedsSplit>(upper_viability) &&
+    if (split_pivot_i + 4 < 68 && batt::is_case<NeedsSplit>(upper_viability) &&
         !batt::is_case<NeedsSplit>(lower_viability)) {
       ++split_pivot_i;
       continue;
@@ -1627,7 +1646,7 @@ void InMemoryNode::UpdateBuffer::SegmentedLevel::drop_after_pivot(i32 pivot_i,
                                                                   llfs::PageLoader& page_loader,
                                                                   const TreeOptions& tree_options)
 {
-  this->drop_pivot_range((Interval<i32>{pivot_i, 64}),
+  this->drop_pivot_range((Interval<i32>{pivot_i, 68}),
                          (Interval<KeyView>{pivot_key, global_max_key()}),
                          page_loader,
                          tree_options);
@@ -1701,7 +1720,17 @@ void InMemoryNode::UpdateBuffer::Segment::insert_pivot(i32 pivot_i, bool is_acti
     this->check_invariants(__FILE__, __LINE__);
   });
 
-  this->active_pivots = insert_bit(this->active_pivots, pivot_i, is_active);
+  if (pivot_i < 64) {
+    // Insert the highest bit from active_pivots to the overflow bit set.
+    //
+    this->active_pivots_overflow =
+        (this->active_pivots_overflow << 1) | ((this->active_pivots >> 63) & u64{1});
+
+    this->active_pivots = insert_bit(this->active_pivots, pivot_i, is_active);
+  } else {
+    const i32 overflow_i = pivot_i - 64;
+    this->active_pivots_overflow = insert_bit(this->active_pivots_overflow, overflow_i, is_active);
+  }
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -1712,6 +1741,8 @@ void InMemoryNode::UpdateBuffer::Segment::pop_front_pivots(i32 count)
     return;
   }
 
+  BATT_CHECK_LT(count, 64);
+
   // Before we modify the bit sets, make sure we aren't losing any active pivots.
   //
   const u64 mask = (u64{1} << count) - 1;
@@ -1719,16 +1750,18 @@ void InMemoryNode::UpdateBuffer::Segment::pop_front_pivots(i32 count)
   BATT_CHECK_EQ(bit_count(mask), count);
   BATT_CHECK_EQ((this->active_pivots & mask), u64{0});
 
-  // Shift the active pivot set down by count.
+  // Shift the active pivot sets down by count.
   //
-  this->active_pivots = (this->active_pivots >> count);
+  this->active_pivots =
+      (this->active_pivots >> count) | (this->active_pivots_overflow << (64 - count));
+  this->active_pivots_overflow = (this->active_pivots_overflow >> count);
 }
 
 //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
 //
 bool InMemoryNode::UpdateBuffer::Segment::is_inactive() const
 {
-  const bool inactive = (this->active_pivots == 0);
+  const bool inactive = (this->active_pivots == 0 && this->active_pivots_overflow == 0);
   if (inactive) {
     Slice<const Interval<u32>> filter_dropped_ranges = this->filter.dropped();
     BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -109,7 +109,7 @@ using PackedSegment = PackedUpdateBuffer::Segment;
         Segment& segment = segmented_level.segments[segment_i];
 
         segment.page_id_slot = llfs::PageIdSlot::from_page_id(packed_segment.leaf_page_id.unpack());
-        segment.active_pivots = packed_segment.active_pivots;
+        segment.active_pivots = packed_segment.active_pivots.unpack();
 
         BATT_ASSIGN_OK_RESULT(segment.filter,
                               packed_node.create_piecewise_filter(level_i, segment_i));

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -16,6 +16,7 @@
 #include <turtle_kv/core/value_view.hpp>
 
 #include <batteries/case_of.hpp>
+#include <batteries/require.hpp>
 
 namespace turtle_kv {
 
@@ -46,6 +47,8 @@ using PackedSegment = PackedUpdateBuffer::Segment;
                                              packed_node.is_size_tiered());
 
   const usize pivot_count = packed_node.pivot_count();
+
+  BATT_REQUIRE_LE(pivot_count, kMaxPivots);
 
   node->tree_options = tree_options;
   node->height = packed_node.height;
@@ -608,6 +611,13 @@ Status InMemoryNode::split_child(BatchUpdateContext& update_context, i32 pivot_i
 #if TURTLE_KV_PROFILE_UPDATES
   update_context.metrics.split_count.add(1);
 #endif
+
+  // Make sure we don't exceed the temporary pivot count limit.
+  //
+  BATT_CHECK_LT(this->pivot_count(), (i32)InMemoryNode::kMaxTempPivots);
+  auto on_scope_exit = batt::finally([&] {
+    BATT_CHECK_LE(this->pivot_count(), (i32)InMemoryNode::kMaxTempPivots);
+  });
 
   Subtree& child = this->children[pivot_i];
 

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -8,6 +8,7 @@
 #include <turtle_kv/tree/leaf_page_view.hpp>
 #include <turtle_kv/tree/node_page_view.hpp>
 #include <turtle_kv/tree/segmented_level_scanner.hpp>
+#include <turtle_kv/tree/subtree_viability.hpp>
 
 #include <turtle_kv/core/algo/split_parts.hpp>
 #include <turtle_kv/core/key_view.hpp>
@@ -979,7 +980,7 @@ SubtreeViability InMemoryNode::get_viability() const
   NeedsMerge needs_merge;
 
   needs_merge.single_pivot = (this->pivot_count() == 1);
-  needs_merge.too_few_pivots = (this->pivot_count() < 4);
+  needs_merge.too_few_pivots = (this->pivot_count() < kMinPivotCount);
 
   if (needs_merge) {
     return needs_merge;
@@ -1118,7 +1119,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
   BATT_CHECK_EQ(orig_pivot_count + 1, orig_pivot_keys.size());
 
-  std::array<u64, 2> tried_already = {0, 0};
+  ActivePivotsSet128 tried_already;
   usize split_pivot_i = (orig_pivot_count + 1) / 2;
 
   auto* node_lower_half = this;
@@ -1133,10 +1134,10 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
   for (;;) {
     // If we ever try the same split point a second time, fail.
     //
-    if (get_bit(tried_already, split_pivot_i)) {
+    if (tried_already.get(split_pivot_i)) {
       return {batt::StatusCode::kInternal};
     }
-    tried_already = set_bit(tried_already, split_pivot_i, true);
+    tried_already.set(split_pivot_i, true);
 
     //+++++++++++-+-+--+----- --- -- -  -  -   -
 
@@ -1258,7 +1259,7 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the lower half is too large, then move the split point down and retry if possible.
     //
-    if (split_pivot_i > 4 && batt::is_case<NeedsSplit>(lower_viability) &&
+    if (split_pivot_i > kMinPivotCount && batt::is_case<NeedsSplit>(lower_viability) &&
         !batt::is_case<NeedsSplit>(upper_viability)) {
       --split_pivot_i;
       continue;
@@ -1266,8 +1267,8 @@ StatusOr<std::unique_ptr<InMemoryNode>> InMemoryNode::try_split_direct(BatchUpda
 
     // If the upper half is too large, then move the split point up and retry if possible.
     //
-    if (split_pivot_i + 4 < orig_pivot_count && batt::is_case<NeedsSplit>(upper_viability) &&
-        !batt::is_case<NeedsSplit>(lower_viability)) {
+    if (split_pivot_i + kMinPivotCount < orig_pivot_count &&
+        batt::is_case<NeedsSplit>(upper_viability) && !batt::is_case<NeedsSplit>(lower_viability)) {
       ++split_pivot_i;
       continue;
     }

--- a/src/turtle_kv/tree/in_memory_node.cpp
+++ b/src/turtle_kv/tree/in_memory_node.cpp
@@ -1720,7 +1720,7 @@ void InMemoryNode::UpdateBuffer::Segment::pop_front_pivots(i32 count)
 //
 bool InMemoryNode::UpdateBuffer::Segment::is_inactive() const
 {
-  const bool inactive = this->active_pivots.is_inactive();
+  const bool inactive = this->active_pivots.is_empty();
   if (inactive) {
     Slice<const Interval<u32>> filter_dropped_ranges = this->filter.dropped();
     BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -85,9 +85,15 @@ struct InMemoryNode {
        */
       llfs::PageIdSlot page_id_slot;
 
-      /** \brief A bit set of pivots in whose key range this segment contains items.
+      /** \brief A bit set of pivots in whose key range this segment contains items. Used for
+       * pivots [0, 64).
        */
       u64 active_pivots = 0;
+
+      /** \brief A bit set of pivots in whose key range this segment contains items. Used for
+       * pivots 64 and greater.
+       */
+      u64 active_pivots_overflow = 0;
 
       /** \brief A filter over the flushed items in this segment.
        */
@@ -110,18 +116,34 @@ struct InMemoryNode {
         return this->active_pivots;
       }
 
+      /** \brief Returns the active pivots bit set, as well as the overflow bit set.
+       */
+      std::pair<u64, u64> get_active_pivots_with_overflow() const
+      {
+        return std::make_pair(this->active_pivots, this->active_pivots_overflow);
+      }
+
       /** \brief Marks this segment as containing (or not) active keys addressed to `pivot_i`.
        */
       void set_pivot_active(i32 pivot_i, bool active)
       {
-        this->active_pivots = set_bit(this->active_pivots, pivot_i, active);
+        if (pivot_i < 64) {
+          this->active_pivots = set_bit(this->active_pivots, pivot_i, active);
+        } else {
+          this->active_pivots_overflow =
+              set_bit(this->active_pivots_overflow, pivot_i - 64, active);
+        }
       }
 
       /** \brief Returns true iff this segment has active keys addressed to `pivot_i`.
        */
       bool is_pivot_active(i32 pivot_i) const
       {
-        return get_bit(this->active_pivots, pivot_i);
+        if (pivot_i < 64) {
+          return get_bit(this->active_pivots, pivot_i);
+        } else {
+          return get_bit(this->active_pivots_overflow, pivot_i - 64);
+        }
       }
 
       template <typename Traits>
@@ -460,12 +482,12 @@ struct InMemoryNode {
 
   usize max_pivot_count() const
   {
-    return this->is_size_tiered() ? (64 - 1) : (64 - 1);
+    return this->is_size_tiered() ? 64 : 64;
   }
 
   usize max_segment_count() const
   {
-    return this->is_size_tiered() ? (64 - 2) : (64 - 2);
+    return this->is_size_tiered() ? (64 - 1) : (64 - 1);
   }
 
   Slice<const KeyView> get_pivot_keys() const

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -129,7 +129,9 @@ struct InMemoryNode {
       void set_pivot_active(i32 pivot_i, bool active)
       {
         std::array<u64, 2> active_pivots_out =
-            set_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i, active);
+            set_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
+                    pivot_i,
+                    active);
         this->active_pivots = active_pivots_out[0];
         this->active_pivots_overflow = active_pivots_out[1];
       }
@@ -138,7 +140,8 @@ struct InMemoryNode {
        */
       bool is_pivot_active(i32 pivot_i) const
       {
-        return get_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i);
+        return get_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
+                       pivot_i);
       }
 
       template <typename Traits>

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <turtle_kv/tree/active_pivots_set.hpp>
 #include <turtle_kv/tree/batch_update.hpp>
 #include <turtle_kv/tree/in_memory_leaf.hpp>
 #include <turtle_kv/tree/max_pending_bytes.hpp>
@@ -89,12 +90,13 @@ struct InMemoryNode {
       /** \brief A bit set of pivots in whose key range this segment contains items. Used for
        * pivots [0, 64).
        */
-      u64 active_pivots = 0;
+      // u64 active_pivots = 0;
+      ActivePivotsSet128 active_pivots;
 
       /** \brief A bit set of pivots in whose key range this segment contains items. Used for
        * pivots 64 and greater.
        */
-      u64 active_pivots_overflow = 0;
+      // u64 active_pivots_overflow = 0;
 
       /** \brief A filter over the flushed items in this segment.
        */
@@ -112,36 +114,32 @@ struct InMemoryNode {
 
       /** \brief Returns the active pivots bit set.
        */
-      u64 get_active_pivots() const
+      auto get_active_pivots() const
       {
         return this->active_pivots;
       }
 
       /** \brief Returns the active pivots bit set, as well as the overflow bit set.
        */
+#if 0
       std::array<u64, 2> get_active_pivots_with_overflow() const
       {
         return {this->active_pivots, this->active_pivots_overflow};
       }
+#endif
 
       /** \brief Marks this segment as containing (or not) active keys addressed to `pivot_i`.
        */
       void set_pivot_active(i32 pivot_i, bool active)
       {
-        std::array<u64, 2> active_pivots_out =
-            set_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
-                    pivot_i,
-                    active);
-        this->active_pivots = active_pivots_out[0];
-        this->active_pivots_overflow = active_pivots_out[1];
+        this->active_pivots.set(pivot_i, active);
       }
 
       /** \brief Returns true iff this segment has active keys addressed to `pivot_i`.
        */
       bool is_pivot_active(i32 pivot_i) const
       {
-        return get_bit(std::array<u64, 2>{this->active_pivots, this->active_pivots_overflow},
-                       pivot_i);
+        return this->active_pivots.get(pivot_i);
       }
 
       template <typename Traits>

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -87,16 +87,9 @@ struct InMemoryNode {
        */
       llfs::PageIdSlot page_id_slot;
 
-      /** \brief A bit set of pivots in whose key range this segment contains items. Used for
-       * pivots [0, 64).
+      /** \brief A bit set of pivots in whose key range this segment contains items.
        */
-      // u64 active_pivots = 0;
       ActivePivotsSet128 active_pivots;
-
-      /** \brief A bit set of pivots in whose key range this segment contains items. Used for
-       * pivots 64 and greater.
-       */
-      // u64 active_pivots_overflow = 0;
 
       /** \brief A filter over the flushed items in this segment.
        */
@@ -118,15 +111,6 @@ struct InMemoryNode {
       {
         return this->active_pivots;
       }
-
-      /** \brief Returns the active pivots bit set, as well as the overflow bit set.
-       */
-#if 0
-      std::array<u64, 2> get_active_pivots_with_overflow() const
-      {
-        return {this->active_pivots, this->active_pivots_overflow};
-      }
-#endif
 
       /** \brief Marks this segment as containing (or not) active keys addressed to `pivot_i`.
        */

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <turtle_kv/tree/algo/segments.hpp>
 #include <turtle_kv/tree/batch_update.hpp>
 #include <turtle_kv/tree/in_memory_leaf.hpp>
 #include <turtle_kv/tree/max_pending_bytes.hpp>
@@ -64,6 +63,8 @@ struct InMemoryNode {
   }
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
+
+  static constexpr usize kMaxTempPivots = 128;
 
   //==#==========+==+=+=++=+++++++++++-+-+--+----- --- -- -  -  -   -
   //
@@ -482,12 +483,12 @@ struct InMemoryNode {
 
   usize max_pivot_count() const
   {
-    return this->is_size_tiered() ? 64 : 64;
+    return this->is_size_tiered() ? kMaxPivots : kMaxPivots;
   }
 
   usize max_segment_count() const
   {
-    return this->is_size_tiered() ? (64 - 1) : (64 - 1);
+    return this->is_size_tiered() ? (kMaxPivots - 1) : (kMaxPivots - 1);
   }
 
   Slice<const KeyView> get_pivot_keys() const

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -107,7 +107,7 @@ struct InMemoryNode {
 
       /** \brief Returns the active pivots bit set.
        */
-      auto get_active_pivots() const
+      ActivePivotsSet128 get_active_pivots() const
       {
         return this->active_pivots;
       }

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -462,12 +462,12 @@ struct InMemoryNode {
 
   usize max_pivot_count() const
   {
-    return this->is_size_tiered() ? kMaxPivots : kMaxPivots;
+    return kMaxPivots;
   }
 
   usize max_segment_count() const
   {
-    return this->is_size_tiered() ? (kMaxPivots - 1) : (kMaxPivots - 1);
+    return kMaxPivots - 1;
   }
 
   Slice<const KeyView> get_pivot_keys() const

--- a/src/turtle_kv/tree/in_memory_node.hpp
+++ b/src/turtle_kv/tree/in_memory_node.hpp
@@ -119,32 +119,26 @@ struct InMemoryNode {
 
       /** \brief Returns the active pivots bit set, as well as the overflow bit set.
        */
-      std::pair<u64, u64> get_active_pivots_with_overflow() const
+      std::array<u64, 2> get_active_pivots_with_overflow() const
       {
-        return std::make_pair(this->active_pivots, this->active_pivots_overflow);
+        return {this->active_pivots, this->active_pivots_overflow};
       }
 
       /** \brief Marks this segment as containing (or not) active keys addressed to `pivot_i`.
        */
       void set_pivot_active(i32 pivot_i, bool active)
       {
-        if (pivot_i < 64) {
-          this->active_pivots = set_bit(this->active_pivots, pivot_i, active);
-        } else {
-          this->active_pivots_overflow =
-              set_bit(this->active_pivots_overflow, pivot_i - 64, active);
-        }
+        std::array<u64, 2> active_pivots_out =
+            set_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i, active);
+        this->active_pivots = active_pivots_out[0];
+        this->active_pivots_overflow = active_pivots_out[1];
       }
 
       /** \brief Returns true iff this segment has active keys addressed to `pivot_i`.
        */
       bool is_pivot_active(i32 pivot_i) const
       {
-        if (pivot_i < 64) {
-          return get_bit(this->active_pivots, pivot_i);
-        } else {
-          return get_bit(this->active_pivots_overflow, pivot_i - 64);
-        }
+        return get_bit({this->active_pivots, this->active_pivots_overflow}, pivot_i);
       }
 
       template <typename Traits>

--- a/src/turtle_kv/tree/packed_node_page.cpp
+++ b/src/turtle_kv/tree/packed_node_page.cpp
@@ -68,7 +68,7 @@ PackedNodePage* build_node_page(const MutableBuffer& buffer, const InMemoryNode&
 
   const usize pivot_count = src_node.pivot_count();
 
-  BATT_CHECK_LE(pivot_count, PackedNodePage::kMaxPivots);
+  BATT_CHECK_LE(pivot_count, kMaxPivots);
   BATT_CHECK_EQ(src_node.pivot_keys_.size(), pivot_count + 1);
   BATT_CHECK_EQ(src_node.children.size(), pivot_count);
   BATT_CHECK_EQ(src_node.pending_bytes.size(), pivot_count);

--- a/src/turtle_kv/tree/packed_node_page.cpp
+++ b/src/turtle_kv/tree/packed_node_page.cpp
@@ -146,8 +146,7 @@ PackedNodePage* build_node_page(const MutableBuffer& buffer, const InMemoryNode&
         dst_segment.leaf_page_id = llfs::PackedPageId::from(src_segment.page_id_slot.page_id);
         dst_segment.active_pivots = src_segment.get_active_pivots();
 
-        BATT_CHECK_EQ(bit_count(src_segment.get_active_pivots()),
-                      bit_count(dst_segment.active_pivots));
+        BATT_CHECK_EQ(src_segment.get_active_pivots().count(), dst_segment.active_pivots.count());
 
         dst_segment.filter_start = BATT_CHECKED_CAST(u16, segment_filters_offset);
 
@@ -494,7 +493,7 @@ std::function<void(std::ostream&)> PackedNodePage::dump() const
           (segment.filter_start.value() & PackedNodePage::kSegmentStartsFiltered) != 0;
       out << "   - [" << std::setw(2) << std::setfill(' ') << i << "]:" << std::endl
           << "     leaf_page_id: " << segment.leaf_page_id.unpack() << std::endl
-          << "     active_pivots:  " << std::bitset<64>{segment.active_pivots.value()} << std::endl
+          << "     active_pivots:  " << segment.active_pivots.printable() << std::endl
           << "     filter_start:  " << filter_start_i << std::endl
           << "     starts_filtered: " << start_filtered << std::endl
           << std::endl;

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -49,7 +49,7 @@ struct PackedNodePage {
       kMaxPivots + 1 /*max_key*/ + 1 /*common_prefix*/ + 1 /*final_offset*/;
 
   static constexpr u8 kFlagSizeTiered = 0x80;
-  static constexpr u8 kPivotCountMask = 0x3f;
+  static constexpr u8 kPivotCountMask = 0x7f;
   static constexpr u16 kSegmentStartsFiltered = 0x8000;
 
   using Key = PackedNodePageKey;
@@ -141,6 +141,11 @@ struct PackedNodePage {
       u64 get_active_pivots() const
       {
         return this->active_pivots;
+      }
+
+      std::pair<u64, u64> get_active_pivots_with_overflow() const
+      {
+        return std::make_pair(this->active_pivots, u64{0});
       }
 
       llfs::PageId get_leaf_page_id() const

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -143,13 +143,6 @@ struct PackedNodePage {
         return this->active_pivots;
       }
 
-#if 0
-      std::array<u64, 2> get_active_pivots_with_overflow() const
-      {
-        return {this->active_pivots, u64{0}};
-      }
-#endif
-
       llfs::PageId get_leaf_page_id() const
       {
         return this->leaf_page_id.unpack();

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -142,9 +142,9 @@ struct PackedNodePage {
         return this->active_pivots;
       }
 
-      std::pair<u64, u64> get_active_pivots_with_overflow() const
+      std::array<u64, 2> get_active_pivots_with_overflow() const
       {
-        return std::make_pair(this->active_pivots, u64{0});
+        return {this->active_pivots, u64{0}};
       }
 
       llfs::PageId get_leaf_page_id() const

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <turtle_kv/tree/active_pivots_set.hpp>
 #include <turtle_kv/tree/key_query.hpp>
 #include <turtle_kv/tree/packed_node_page_key.hpp>
 
@@ -126,26 +127,28 @@ struct PackedNodePage {
     };
 
     struct Segment {
-      llfs::PackedPageId leaf_page_id;  // +8 -> 8
-      little_u64 active_pivots;         // +8 -> 16
-      little_u16 filter_start;          // +2 -> 18
+      llfs::PackedPageId leaf_page_id;        // +8 -> 8
+      PackedActivePivotsSet64 active_pivots;  // +8 -> 16
+      little_u16 filter_start;                // +2 -> 18
 
       //+++++++++++-+-+--+----- --- -- -  -  -   -
 
       bool is_pivot_active(i32 pivot_i) const
       {
-        return get_bit(this->active_pivots, pivot_i);
+        return this->active_pivots.get(pivot_i);
       }
 
-      u64 get_active_pivots() const
+      PackedActivePivotsSet64 get_active_pivots() const
       {
         return this->active_pivots;
       }
 
+#if 0
       std::array<u64, 2> get_active_pivots_with_overflow() const
       {
         return {this->active_pivots, u64{0}};
       }
+#endif
 
       llfs::PageId get_leaf_page_id() const
       {

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -49,7 +49,7 @@ struct PackedNodePage {
       kMaxPivots + 1 /*max_key*/ + 1 /*common_prefix*/ + 1 /*final_offset*/;
 
   static constexpr u8 kFlagSizeTiered = 0x80;
-  static constexpr u8 kPivotCountMask = 0x7f;
+  static constexpr u8 kPivotCountMask = 0x7f;  // Needs to be at least 64
   static constexpr u16 kSegmentStartsFiltered = 0x8000;
 
   using Key = PackedNodePageKey;

--- a/src/turtle_kv/tree/packed_node_page.hpp
+++ b/src/turtle_kv/tree/packed_node_page.hpp
@@ -42,7 +42,6 @@ struct Subtree;
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 
 struct PackedNodePage {
-  static constexpr usize kMaxPivots = 64;
   static constexpr usize kMaxSegments = kMaxPivots - 1;
   static constexpr usize kMaxLevels = batt::log2_ceil(kMaxPivots);
   static constexpr usize kPivotKeysSize =

--- a/src/turtle_kv/tree/segmented_level_scanner.hpp
+++ b/src/turtle_kv/tree/segmented_level_scanner.hpp
@@ -207,7 +207,7 @@ inline auto SegmentedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bo
   const Segment* segment = std::addressof(this->level_->get_segment(this->segment_i_));
 
   ActivePivotsSetT active_pivots = segment->get_active_pivots();
-  BATT_CHECK(!active_pivots.is_inactive()) << "This segment should have been dropped!";
+  BATT_CHECK(!active_pivots.is_empty()) << "This segment should have been dropped!";
 
   // Make sure we have a leaf page loaded.
   //

--- a/src/turtle_kv/tree/segmented_level_scanner.hpp
+++ b/src/turtle_kv/tree/segmented_level_scanner.hpp
@@ -53,6 +53,7 @@ class SegmentedLevelScanner : private SegmentedLevelScannerBase
   using PageLoader = PageLoaderT;
   using PinnedPageT = typename PageLoader::PinnedPageT;
   using Segment = typename Level::Segment;
+  using ActivePivotsSetT = decltype(std::declval<const Segment&>().get_active_pivots());
 
   using Item = EditSlice;
 
@@ -205,8 +206,8 @@ inline auto SegmentedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bo
 
   const Segment* segment = std::addressof(this->level_->get_segment(this->segment_i_));
 
-  u64 active_pivots = segment->get_active_pivots();
-  BATT_CHECK_NE(active_pivots, 0) << "This segment should have been dropped!";
+  ActivePivotsSetT active_pivots = segment->get_active_pivots();
+  BATT_CHECK(!active_pivots.is_inactive()) << "This segment should have been dropped!";
 
   // Make sure we have a leaf page loaded.
   //
@@ -215,7 +216,7 @@ inline auto SegmentedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bo
 
     // Skip ahead to the next segment that is active at or past the minimum pivot.
     //
-    while (last_bit(active_pivots) < this->min_pivot_i_) {
+    while (active_pivots.last() < this->min_pivot_i_) {
       ++this->segment_i_;
       if (this->segment_i_ == this->level_->segment_count()) {
         return None;
@@ -238,9 +239,8 @@ inline auto SegmentedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bo
 
     this->pinned_leaf_ = std::move(*loaded_page);
 
-    i32 target_pivot_i = std::max(first_bit(active_pivots), this->min_pivot_i_);
-    while (target_pivot_i < (i32)this->node_->pivot_count() &&
-           !get_bit(active_pivots, target_pivot_i)) {
+    i32 target_pivot_i = std::max(active_pivots.first(), this->min_pivot_i_);
+    while (target_pivot_i < (i32)this->node_->pivot_count() && !active_pivots.get(target_pivot_i)) {
       ++target_pivot_i;
     }
 

--- a/src/turtle_kv/tree/segmented_level_scanner.hpp
+++ b/src/turtle_kv/tree/segmented_level_scanner.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <turtle_kv/tree/active_pivots_set.hpp>
 #include <turtle_kv/tree/leaf_page_view.hpp>
 #include <turtle_kv/tree/packed_leaf_page.hpp>
 
@@ -54,6 +55,8 @@ class SegmentedLevelScanner : private SegmentedLevelScannerBase
   using PinnedPageT = typename PageLoader::PinnedPageT;
   using Segment = typename Level::Segment;
   using ActivePivotsSetT = decltype(std::declval<const Segment&>().get_active_pivots());
+
+  static_assert(ActivePivotsSet<ActivePivotsSetT>);
 
   using Item = EditSlice;
 

--- a/src/turtle_kv/tree/segmented_level_scanner.test.cpp
+++ b/src/turtle_kv/tree/segmented_level_scanner.test.cpp
@@ -281,8 +281,6 @@ TEST_F(SegmentedLevelScannerTest, Test)
 
 void SegmentedLevelScannerTest::Scenario::run_with_pivot_count(usize pivot_count)
 {
-  constexpr usize kMaxPivotCount = 64;
-
   // Configure the test.
   //
   const bool debug_output = false;
@@ -350,7 +348,7 @@ void SegmentedLevelScannerTest::Scenario::run_with_pivot_count(usize pivot_count
 
     if (debug_output) {
       std::cout << BATT_INSPECT(segment_i) << BATT_INSPECT(leaf_view.get_key_crange()) << "\t"
-                << std::bitset<kMaxPivotCount>{fake_segment.get_active_pivots()} << " "
+                << fake_segment.get_active_pivots().printable() << " "
                 << batt::dump_range(fake_segment.pivot_items_count_) << std::endl;
     }
   }
@@ -424,7 +422,7 @@ void SegmentedLevelScannerTest::Scenario::run_with_pivot_count(usize pivot_count
 
       if (debug_output) {
         std::cout << std::setw(3) << segment_i
-                  << ": active=" << std::bitset<kMaxPivotCount>{segment.get_active_pivots()}
+                  << ": active=" << segment.get_active_pivots().printable()
                   << std::endl;
       }
     }

--- a/src/turtle_kv/tree/sharded_level_scanner.hpp
+++ b/src/turtle_kv/tree/sharded_level_scanner.hpp
@@ -244,7 +244,7 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bool
 
   ActivePivotsSetT active_pivots = segment->get_active_pivots();
   {
-    BATT_CHECK(!active_pivots.is_inactive()) << "This segment should have been dropped!";
+    BATT_CHECK(!active_pivots.is_empty()) << "This segment should have been dropped!";
   }
 
   // Check for need to load new segment.

--- a/src/turtle_kv/tree/sharded_level_scanner.hpp
+++ b/src/turtle_kv/tree/sharded_level_scanner.hpp
@@ -67,6 +67,7 @@ class ShardedLevelScanner : private SegmentedLevelScannerBase
   using PageLoader = PageLoaderT;
   using PinnedPageT = typename PageLoader::PinnedPageT;
   using Segment = typename Level::Segment;
+  using ActivePivotsSetT = decltype(std::declval<const Segment&>().get_active_pivots());
 
   using Item = ShardedKeyValueSlice;
 
@@ -143,11 +144,11 @@ class ShardedLevelScanner : private SegmentedLevelScannerBase
   void update_cached_items(usize prev_item_i);
 
   Optional<Item> continue_full_leaf_after_segment_check(bool advance,
-                                                        u64 active_pivots,
+                                                        ActivePivotsSetT active_pivots,
                                                         const Segment* segment) noexcept;
 
   Optional<Item> continue_sharded_after_segment_check(bool advance,
-                                                      u64 active_pivots,
+                                                      ActivePivotsSetT active_pivots,
                                                       const Segment* segment) noexcept;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -241,9 +242,9 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bool
 
   const Segment* segment = std::addressof(this->level_->get_segment(this->segment_i_));
 
-  u64 active_pivots = segment->get_active_pivots();
+  ActivePivotsSetT active_pivots = segment->get_active_pivots();
   {
-    BATT_CHECK_NE(active_pivots, 0) << "This segment should have been dropped!";
+    BATT_CHECK(!active_pivots.is_inactive()) << "This segment should have been dropped!";
   }
 
   // Check for need to load new segment.
@@ -253,7 +254,7 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bool
 
     // Skip ahead to the next segment that is active at or past the minimum pivot.
     //
-    while (last_bit(active_pivots) < this->min_pivot_i_) {
+    while (active_pivots.last() < this->min_pivot_i_) {
       ++this->segment_i_;
       if (this->segment_i_ == this->level_->segment_count()) {
         return None;
@@ -262,9 +263,8 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bool
       active_pivots = segment->get_active_pivots();
     }
 
-    i32 target_pivot_i = std::max(first_bit(active_pivots), this->min_pivot_i_);
-    while (target_pivot_i < (i32)this->node_->pivot_count() &&
-           !get_bit(active_pivots, target_pivot_i)) {
+    i32 target_pivot_i = std::max(active_pivots.first(), this->min_pivot_i_);
+    while (target_pivot_i < (i32)this->node_->pivot_count() && !active_pivots.get(target_pivot_i)) {
       ++target_pivot_i;
     }
 
@@ -342,7 +342,7 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::peek_next_impl(bool
 template <typename NodeT, typename LevelT, typename PageLoaderT>
 inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::continue_sharded_after_segment_check(
     bool advance,
-    u64 active_pivots,
+    ActivePivotsSetT active_pivots,
     const Segment* segment) noexcept -> Optional<Item>
 {
   const void* page_start = this->head_shard_slice_.data();
@@ -417,7 +417,7 @@ inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::continue_sharded_af
 template <typename NodeT, typename LevelT, typename PageLoaderT>
 inline auto ShardedLevelScanner<NodeT, LevelT, PageLoaderT>::continue_full_leaf_after_segment_check(
     bool advance,
-    u64 active_pivots,
+    ActivePivotsSetT active_pivots,
     const Segment* segment) noexcept -> Optional<Item>
 {
   const PackedLeafPage& leaf_page =

--- a/src/turtle_kv/tree/sharded_level_scanner.hpp
+++ b/src/turtle_kv/tree/sharded_level_scanner.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <turtle_kv/tree/active_pivots_set.hpp>
 #include <turtle_kv/tree/segmented_level_scanner.hpp>
 
 #include <turtle_kv/core/sharded_key_value_slice.hpp>
@@ -68,6 +69,8 @@ class ShardedLevelScanner : private SegmentedLevelScannerBase
   using PinnedPageT = typename PageLoader::PinnedPageT;
   using Segment = typename Level::Segment;
   using ActivePivotsSetT = decltype(std::declval<const Segment&>().get_active_pivots());
+
+  static_assert(ActivePivotsSet<ActivePivotsSetT>);
 
   using Item = ShardedKeyValueSlice;
 

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <turtle_kv/config.hpp>
-//
-
 #include <turtle_kv/import/int_types.hpp>
 
 #include <batteries/case_of.hpp>

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <turtle_kv/import/int_types.hpp>
+
 #include <batteries/case_of.hpp>
 #include <batteries/static_assert.hpp>
 
@@ -7,6 +9,10 @@
 #include <variant>
 
 namespace turtle_kv {
+
+/** \brief The minimum number of pivots allowed in a non-root node.
+ */
+inline constexpr u16 kMinPivotCount = 4;
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //
@@ -107,9 +113,9 @@ inline bool compacting_levels_might_fix(const SubtreeViability& viability)
       },
       [](const NeedsSplit& needs_split) {
         return (needs_split.segment_filters_too_large ||  //
-                needs_split.too_many_segments) &&             //
-               !needs_split.items_too_large &&                //
-               !needs_split.keys_too_large &&                 //
+                needs_split.too_many_segments) &&         //
+               !needs_split.items_too_large &&            //
+               !needs_split.keys_too_large &&             //
                !needs_split.too_many_pivots;
       });
 }
@@ -130,11 +136,11 @@ inline bool normal_flush_might_fix(const SubtreeViability& viability)
         return false;
       },
       [](const NeedsSplit& needs_split) {
-        return needs_split.height == 2 &&                  //
-               (needs_split.segment_filters_too_large      //
-                || needs_split.too_many_segments) &&       //
-               !needs_split.items_too_large &&             //
-               !needs_split.keys_too_large &&              //
+        return needs_split.height == 2 &&              //
+               (needs_split.segment_filters_too_large  //
+                || needs_split.too_many_segments) &&   //
+               !needs_split.items_too_large &&         //
+               !needs_split.keys_too_large &&          //
                !needs_split.too_many_pivots;
       });
 }

--- a/src/turtle_kv/tree/subtree_viability.hpp
+++ b/src/turtle_kv/tree/subtree_viability.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <turtle_kv/config.hpp>
+//
+
 #include <turtle_kv/import/int_types.hpp>
 
 #include <batteries/case_of.hpp>
@@ -9,10 +12,6 @@
 #include <variant>
 
 namespace turtle_kv {
-
-/** \brief The minimum number of pivots allowed in a non-root node.
- */
-inline constexpr u16 kMinPivotCount = 4;
 
 //=#=#==#==#===============+=+=+=+=++=++++++++++++++-++-+--+-+----+---------------
 //

--- a/src/turtle_kv/tree/testing/fake_segment.hpp
+++ b/src/turtle_kv/tree/testing/fake_segment.hpp
@@ -25,7 +25,8 @@ struct FakeLevel;
 struct FakeSegment {
   llfs::PageId page_id_;
   u64 active_pivots_ = 0;
-  PiecewiseFilter<u32> filter;
+  u64 active_pivots_overflow_ = 0;
+  PiecewiseFilter<u32> filter_;
   std::map<usize, usize> pivot_items_count_;
 
   //+++++++++++-+-+--+----- --- -- -  -  -   -
@@ -47,24 +48,48 @@ struct FakeSegment {
     return this->active_pivots_;
   }
 
-  bool is_pivot_active(usize pivot_i) const
+  std::pair<u64, u64> get_active_pivots_with_overflow() const
   {
-    return get_bit(this->active_pivots_, pivot_i);
+    return std::make_pair(this->active_pivots_, this->active_pivots_overflow_);
   }
 
-  void set_pivot_active(usize pivot_i, bool active)
+  bool is_pivot_active(i32 pivot_i) const
   {
-    this->active_pivots_ = set_bit(this->active_pivots_, pivot_i, active);
+    if (pivot_i < 64) {
+      return get_bit(this->active_pivots_, pivot_i);
+    } else {
+      return get_bit(this->active_pivots_overflow_, pivot_i - 64);
+    }
+  }
+
+  void set_pivot_active(i32 pivot_i, bool active)
+  {
+    if (pivot_i < 64) {
+      this->active_pivots_ = set_bit(this->active_pivots_, pivot_i, active);
+    } else {
+      this->active_pivots_overflow_ = set_bit(this->active_pivots_overflow_, pivot_i - 64, active);
+    }
   }
 
   void insert_active_pivot(usize pivot_i, bool is_active = true)
   {
-    this->active_pivots_ = insert_bit(this->active_pivots_, pivot_i, is_active);
+    if (pivot_i < 64) {
+      // Insert the highest bit from active_pivots to the overflow bit set.
+      //
+      this->active_pivots_overflow_ =
+          (this->active_pivots_overflow_ << 1) | ((this->active_pivots_ >> 63) & u64{1});
+
+      this->active_pivots_ = insert_bit(this->active_pivots_, pivot_i, is_active);
+    } else {
+      const i32 overflow_i = pivot_i - 64;
+      this->active_pivots_overflow_ =
+          insert_bit(this->active_pivots_overflow_, overflow_i, is_active);
+    }
   }
 
   void set_pivot_items_count(usize pivot_i, usize count)
   {
-    this->active_pivots_ = set_bit(this->active_pivots_, pivot_i, (count > 0));
+    this->set_pivot_active(pivot_i, (count > 0));
     if (count > 0) {
       this->pivot_items_count_[pivot_i] = count;
     } else {
@@ -88,36 +113,47 @@ struct FakeSegment {
     this->pivot_items_count_.clear();
   }
 
+  bool is_inactive() const
+  {
+    const bool inactive = (this->active_pivots_ == 0 && this->active_pivots_overflow_ == 0);
+    if (inactive) {
+      Slice<const Interval<u32>> filter_dropped_ranges = this->filter_.dropped();
+      BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);
+      BATT_CHECK_EQ(filter_dropped_ranges[0].lower_bound, 0);
+    }
+    return inactive;
+  }
+
   template <typename Traits>
   void drop_key_range(const BasicInterval<Traits>& key_range,
                       const Slice<const PackedKeyValue>& items)
   {
-    drop_item_range(this->filter, items, key_range, llfs::KeyRangeOrder{});
+    drop_item_range(this->filter_, items, key_range, llfs::KeyRangeOrder{});
   }
 
   void drop_index_range(Interval<u32> i)
   {
-    this->filter.drop_index_range(i);
+    this->filter_.drop_index_range(i);
   }
 
   bool is_index_filtered(const FakeLevel&, u32 index) const
   {
-    return !this->filter.live_at_index(index);
+    return !this->filter_.live_at_index(index);
   }
 
   bool is_unfiltered() const
   {
-    return !this->filter.dropped_total();
+    return !this->filter_.dropped_total();
   }
 
   u32 live_lower_bound(const FakeLevel&, u32 item_i) const
   {
-    return this->filter.live_lower_bound(item_i);
+    return this->filter_.live_lower_bound(item_i);
   }
 
   Interval<u32> get_live_item_range(const FakeLevel&, Interval<u32> i) const
   {
-    return this->filter.find_live_range(i);
+    return this->filter_.find_live_range(i);
   }
 };
 

--- a/src/turtle_kv/tree/testing/fake_segment.hpp
+++ b/src/turtle_kv/tree/testing/fake_segment.hpp
@@ -2,6 +2,8 @@
 
 #include <turtle_kv/tree/testing/fake_page_loader.hpp>
 
+#include <turtle_kv/tree/active_pivots_set.hpp>
+
 #include <turtle_kv/core/packed_key_value.hpp>
 
 #include <turtle_kv/util/piecewise_filter.hpp>
@@ -24,8 +26,7 @@ struct FakeLevel;
 //
 struct FakeSegment {
   llfs::PageId page_id_;
-  u64 active_pivots_ = 0;
-  u64 active_pivots_overflow_ = 0;
+  ActivePivotsSet128 active_pivots_ = {};
   PiecewiseFilter<u32> filter_;
   std::map<usize, usize> pivot_items_count_;
 
@@ -43,40 +44,24 @@ struct FakeSegment {
                             });
   }
 
-  u64 get_active_pivots() const
+  auto get_active_pivots() const
   {
     return this->active_pivots_;
   }
 
-  std::pair<u64, u64> get_active_pivots_with_overflow() const
-  {
-    return std::make_pair(this->active_pivots_, this->active_pivots_overflow_);
-  }
-
   bool is_pivot_active(i32 pivot_i) const
   {
-    return get_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
-                   pivot_i);
+    return this->active_pivots_.get(pivot_i);
   }
 
   void set_pivot_active(i32 pivot_i, bool active)
   {
-    std::array<u64, 2> active_pivots_out =
-        set_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
-                pivot_i,
-                active);
-    this->active_pivots_ = active_pivots_out[0];
-    this->active_pivots_overflow_ = active_pivots_out[1];
+    this->active_pivots_.set(pivot_i, active);
   }
 
   void insert_active_pivot(usize pivot_i, bool is_active = true)
   {
-    std::array<u64, 2> active_pivots_out =
-        insert_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
-                   pivot_i,
-                   is_active);
-    this->active_pivots_ = active_pivots_out[0];
-    this->active_pivots_overflow_ = active_pivots_out[1];
+    this->active_pivots_.insert(pivot_i, is_active);
   }
 
   void set_pivot_items_count(usize pivot_i, usize count)
@@ -101,13 +86,13 @@ struct FakeSegment {
 
   void clear_active_pivots()
   {
-    this->active_pivots_ = 0;
+    this->active_pivots_ = {};
     this->pivot_items_count_.clear();
   }
 
   bool is_inactive() const
   {
-    const bool inactive = (this->active_pivots_ == 0 && this->active_pivots_overflow_ == 0);
+    const bool inactive = this->active_pivots_.is_inactive();
     if (inactive) {
       Slice<const Interval<u32>> filter_dropped_ranges = this->filter_.dropped();
       BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);

--- a/src/turtle_kv/tree/testing/fake_segment.hpp
+++ b/src/turtle_kv/tree/testing/fake_segment.hpp
@@ -44,7 +44,7 @@ struct FakeSegment {
                             });
   }
 
-  auto get_active_pivots() const
+  ActivePivotsSet128 get_active_pivots() const
   {
     return this->active_pivots_;
   }
@@ -92,7 +92,7 @@ struct FakeSegment {
 
   bool is_inactive() const
   {
-    const bool inactive = this->active_pivots_.is_inactive();
+    const bool inactive = this->active_pivots_.is_empty();
     if (inactive) {
       Slice<const Interval<u32>> filter_dropped_ranges = this->filter_.dropped();
       BATT_CHECK_EQ(filter_dropped_ranges.size(), 1);

--- a/src/turtle_kv/tree/testing/fake_segment.hpp
+++ b/src/turtle_kv/tree/testing/fake_segment.hpp
@@ -55,36 +55,28 @@ struct FakeSegment {
 
   bool is_pivot_active(i32 pivot_i) const
   {
-    if (pivot_i < 64) {
-      return get_bit(this->active_pivots_, pivot_i);
-    } else {
-      return get_bit(this->active_pivots_overflow_, pivot_i - 64);
-    }
+    return get_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
+                   pivot_i);
   }
 
   void set_pivot_active(i32 pivot_i, bool active)
   {
-    if (pivot_i < 64) {
-      this->active_pivots_ = set_bit(this->active_pivots_, pivot_i, active);
-    } else {
-      this->active_pivots_overflow_ = set_bit(this->active_pivots_overflow_, pivot_i - 64, active);
-    }
+    std::array<u64, 2> active_pivots_out =
+        set_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
+                pivot_i,
+                active);
+    this->active_pivots_ = active_pivots_out[0];
+    this->active_pivots_overflow_ = active_pivots_out[1];
   }
 
   void insert_active_pivot(usize pivot_i, bool is_active = true)
   {
-    if (pivot_i < 64) {
-      // Insert the highest bit from active_pivots to the overflow bit set.
-      //
-      this->active_pivots_overflow_ =
-          (this->active_pivots_overflow_ << 1) | ((this->active_pivots_ >> 63) & u64{1});
-
-      this->active_pivots_ = insert_bit(this->active_pivots_, pivot_i, is_active);
-    } else {
-      const i32 overflow_i = pivot_i - 64;
-      this->active_pivots_overflow_ =
-          insert_bit(this->active_pivots_overflow_, overflow_i, is_active);
-    }
+    std::array<u64, 2> active_pivots_out =
+        insert_bit(std::array<u64, 2>{this->active_pivots_, this->active_pivots_overflow_},
+                   pivot_i,
+                   is_active);
+    this->active_pivots_ = active_pivots_out[0];
+    this->active_pivots_overflow_ = active_pivots_out[1];
   }
 
   void set_pivot_items_count(usize pivot_i, usize count)

--- a/src/turtle_kv/util/piecewise_filter.ipp
+++ b/src/turtle_kv/util/piecewise_filter.ipp
@@ -154,7 +154,7 @@ Interval<OffsetT> PiecewiseFilter<OffsetT>::find_live_range(Interval<OffsetT> i)
   OffsetT start_i = i.lower_bound;
   OffsetT end_i = i.upper_bound;
 
-  BATT_CHECK_LT(start_i, end_i);
+  BATT_CHECK_LE(start_i, end_i);
 
   auto iter = std::lower_bound(this->dropped_.begin(),
                                this->dropped_.end(),
@@ -183,7 +183,7 @@ Interval<OffsetT> PiecewiseFilter<OffsetT>::find_live_range(Interval<OffsetT> i)
     end_i = std::min(end_i, iter->lower_bound);
   }
 
-  BATT_CHECK_LT(start_i, end_i) << BATT_INSPECT(i);
+  BATT_CHECK_LE(start_i, end_i) << BATT_INSPECT(i);
 
   return Interval<OffsetT>{start_i, end_i};
 }

--- a/src/turtle_kv/util/piecewise_filter.test.cpp
+++ b/src/turtle_kv/util/piecewise_filter.test.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <random>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -63,68 +64,82 @@ TEST(PiecewiseFilterTest, InvalidFilterTest)
 //
 TEST(PiecewiseFilterTest, QueryTest)
 {
+  const usize num_items = 1000000;
+
   for (usize i = 0; i < 100; ++i) {
     std::default_random_engine rng{i};
-    std::uniform_int_distribution<usize> pick_num_items{10, ~usize{0} - 1};
-    const usize num_items = pick_num_items(rng);
 
     PiecewiseFilter<usize> filter;
+    EXPECT_TRUE(filter.check_invariants());
 
-    // First verify that everything should be live since nothing has been dropped yet.
+    // All items start unfiltered.
     //
-    EXPECT_EQ(filter.dropped_total(), 0);
+    std::set<usize> live_items;
+    for (usize i = 0; i < num_items; ++i) {
+      live_items.insert(i);
+    }
 
-    Interval<usize> next_live_interval = filter.find_live_range(Interval<usize>{0, num_items});
-    EXPECT_EQ(next_live_interval, (Interval<usize>{0, num_items}));
-
-    // Drop some items from the start.
+    // Drop random intervals.
     //
-    filter.drop_index_range(Interval<usize>{0, num_items / 10});
+    std::uniform_int_distribution<usize> pick_num_dropped{100, num_items / 2};
+    usize num_intervals_dropped = pick_num_dropped(rng);
+    for (usize i = 0; i < num_intervals_dropped; ++i) {
+      std::uniform_int_distribution<usize> pick_interval_start{0, num_items - 1};
+      usize start_i = pick_interval_start(rng);
 
-    EXPECT_EQ(filter.dropped_total(), num_items / 10);
+      std::uniform_int_distribution<usize> pick_interval_end{start_i, num_items};
+      usize end_i = pick_interval_end(rng);
 
-    EXPECT_FALSE(filter.live_at_index(0));
-    EXPECT_TRUE(filter.live_at_index(num_items / 10));
+      for (usize j = start_i; j < end_i; ++j) {
+        live_items.erase(j);
+      }
 
-    EXPECT_EQ(filter.live_lower_bound(0), num_items / 10);
-    EXPECT_EQ(filter.live_lower_bound(num_items / 10), num_items / 10);
-
-    EXPECT_EQ(filter.find_live_range(Interval<usize>{0, num_items}),
-              (Interval<usize>{num_items / 10, num_items}));
-
-    // Drop some more items from the middle of the item range (not overlapping with the previous
-    // interval).
-    //
-    filter.drop_index_range(Interval<usize>{num_items / 2, (num_items / 5) * 3});
-
-    usize dropped_item_count = (num_items / 10) + ((num_items / 5) * 3) - (num_items / 2);
-    EXPECT_EQ(filter.dropped_total(), dropped_item_count);
-
-    EXPECT_FALSE(filter.live_at_index(num_items / 2));
-    EXPECT_TRUE(filter.live_at_index(num_items / 5));
-    EXPECT_TRUE(filter.live_at_index((num_items / 5) * 4));
-
-    EXPECT_EQ(filter.live_lower_bound(num_items / 10), num_items / 10);
-    EXPECT_EQ(filter.live_lower_bound(num_items / 5), num_items / 5);
-    EXPECT_EQ(filter.live_lower_bound((num_items / 5) * 4), (num_items / 5) * 4);
-
-    EXPECT_EQ(filter.find_live_range(Interval<usize>{0, num_items}),
-              (Interval<usize>{num_items / 10, num_items / 2}));
-
-    EXPECT_EQ(filter.find_live_range(Interval<usize>{num_items / 10, (num_items / 5) * 2}),
-              (Interval<usize>{num_items / 10, (num_items / 5) * 2}));
-
-    // Drop a range with some overlap with the previous ranges.
-    //
-    filter.drop_index_range(Interval<usize>{num_items / 10, (num_items / 5) * 3});
-
-    EXPECT_FALSE(filter.live_at_index(num_items / 5));
-    EXPECT_TRUE(filter.live_at_index((num_items / 5) * 3));
-
-    EXPECT_EQ(filter.find_live_range(Interval<usize>{0, num_items}),
-              (Interval<usize>{(num_items / 5) * 3, num_items}));
+      filter.drop_index_range(Interval<usize>{start_i, end_i});
+    }
 
     EXPECT_TRUE(filter.check_invariants());
+
+    // Test live_at_index
+    //
+    for (usize i = 0; i < num_items; ++i) {
+      EXPECT_EQ(filter.live_at_index(i), live_items.count(i) > 0);
+    }
+
+    // Test live_lower_bound
+    //
+    for (usize i = 0; i < num_items; ++i) {
+      auto iter = live_items.lower_bound(i);
+      usize expected = (iter != live_items.end()) ? *iter : num_items;
+      EXPECT_EQ(filter.live_lower_bound(i), expected);
+    }
+
+    // Test find_live_range
+    //
+    for (usize i = 0; i < 100; ++i) {
+      std::uniform_int_distribution<usize> pick_interval_start{0, num_items - 1};
+      usize start_i = pick_interval_start(rng);
+
+      std::uniform_int_distribution<usize> pick_interval_end{start_i, num_items};
+      usize end_i = pick_interval_end(rng);
+
+      auto iter = live_items.lower_bound(start_i);
+      if (iter == live_items.end() || *iter >= end_i) {
+        EXPECT_EQ(filter.find_live_range(Interval<usize>{start_i, end_i}),
+                  (Interval<usize>{end_i, end_i}));
+      } else {
+        usize first = *iter;
+        usize last = first;
+        auto next = iter;
+
+        while (next != live_items.end() && *next < end_i && *next == last) {
+          ++last;
+          ++next;
+        }
+
+        EXPECT_EQ(filter.find_live_range(Interval<usize>{start_i, end_i}),
+                  (Interval<usize>{first, last}));
+      }
+    }
   }
 }
 

--- a/src/turtle_kv/util/piecewise_filter.test.cpp
+++ b/src/turtle_kv/util/piecewise_filter.test.cpp
@@ -64,10 +64,10 @@ TEST(PiecewiseFilterTest, InvalidFilterTest)
 //
 TEST(PiecewiseFilterTest, QueryTest)
 {
-  const usize num_items = 1000000;
+  const usize num_items = 1000;
 
-  for (usize i = 0; i < 100; ++i) {
-    std::default_random_engine rng{i};
+  for (usize seed = 0; seed < 100; ++seed) {
+    std::default_random_engine rng{seed};
 
     PiecewiseFilter<usize> filter;
     EXPECT_TRUE(filter.check_invariants());


### PR DESCRIPTION
Adds another 64-bit bit set to `InMemoryNode::UpdateBuffer::Segment` in order to handle the intermediate steps involved in node merging, during which pivot count could exceed 64.